### PR TITLE
fix: hibernation on battery & support for models

### DIFF
--- a/App/Gui/GuiTray.cs
+++ b/App/Gui/GuiTray.cs
@@ -109,7 +109,9 @@ namespace OmenMon.AppGui {
                 this.HeartbeatTimer = new System.Windows.Forms.Timer(Components);
                 this.HeartbeatTimer.Interval = Config.BiosHeartbeatInterval;
                 this.HeartbeatTimer.Tick += EventHeartbeatTick;
-                this.HeartbeatTimer.Enabled = true;
+                // Pause immediately if starting on battery (prevents hibernate on battery)
+                this.HeartbeatTimer.Enabled = !Config.BiosHeartbeatPauseOnBattery
+                    || this.Op.Platform.System.IsFullPower();
             }
 
             // Show the main form if requested by the environment variable
@@ -186,8 +188,14 @@ namespace OmenMon.AppGui {
 
             // Only respond to status change events,
             // which excludes Resume and Suspend
-            if(e.Mode == PowerModes.StatusChange)
+            if(e.Mode == PowerModes.StatusChange) {
                 this.Op.PowerChange();
+
+                // Pause BIOS heartbeat on battery to prevent HP firmware from triggering
+                // unexpected hibernate; re-enable it when AC power is restored
+                if(this.HeartbeatTimer != null && Config.BiosHeartbeatPauseOnBattery)
+                    this.HeartbeatTimer.Enabled = this.Op.Platform.System.IsFullPower();
+            }
 
         }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,14 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [1.1.0] - 2026-05-01
+## [1.1.1-reborn] - 2026-05-04
+
+### Fixed
+- **Unexpected Hibernate on Battery (Critical):** OmenMon's BIOS heartbeat timer (`GetFanCount()` every 30 s) kept HP's "Performance Control" session alive on battery power. On certain HP OMEN/Victus firmware revisions this conflicts with the BIOS battery manager and causes the system to force hibernate without warning after extended battery use. The heartbeat is now automatically paused when on battery and resumed when AC is restored.
 
 ### Added
-- **RGB Preset Cycling:** The Omen key can now be used as a hotkey to seamlessly cycle through all `<ColorPresets>` defined in the `OmenMon.xml` without opening the GUI.
-- **Smart Color Detection:** The `CycleColorPresets()` logic automatically detects the active hardware colors and wraps around the preset list sequentially.
-- **New XML Flags:** Added `<KeyToggleColorPreset>` to enable the new RGB feature and `<KeyToggleColorPresetSilent>` to optionally suppress the balloon tip notification.
-
-### Changed
-- **Hotkey Priority:** RGB preset cycling now takes highest precedence in the `KeyHandler` chain over Fan Program toggling and Custom Actions.
-- **Safer Startup Defaults:** `<AutoConfig>` is now set to `false` by default to prevent silent crashes during Windows startup when WMI/EC services are not fully initialized yet.
-- **Optimized Power Profile:** The `<GpuPower>` for the default "Power" program and `<GpuPowerDefault>` have been changed from `Maximum` to `Default` (Base Power). This prevents the system from automatically overriding the user's choice and jumping to "Cool" mode, ensuring maximum fan speeds with balanced heat generation.
+- **`BiosHeartbeatPauseOnBattery` config option:** Controls whether the heartbeat pauses on battery (default: `true`). Set to `false` in `OmenMon.xml` only if you experience fan control issues while on battery.
+- **`INSTRUCTION.md`:** Comprehensive user guide covering all fan modes (including legacy modes), fan programs, battery care, keyboard RGB, CLI reference, configuration, and known issues.
 
 ## [1.0.0-reborn] - 2026-04-30
 

--- a/INSTRUCTION.md
+++ b/INSTRUCTION.md
@@ -1,0 +1,310 @@
+# OmenMon — User Instructions
+
+> For the full GitHub Wiki, see: [wiki/Home.md](wiki/Home.md)
+
+---
+
+## Table of Contents
+
+1. [Quick Start](#quick-start)
+2. [Fan Control Modes](#fan-control-modes)
+   - [Auto (Default)](#auto-default)
+   - [Performance](#performance)
+   - [Cool](#cool)
+   - [Const (Custom Speed)](#const-custom-speed)
+   - [Fan Programs (Temperature Curves)](#fan-programs-temperature-curves)
+   - [Max & Off](#max--off)
+   - [Legacy Modes](#legacy-modes)
+3. [Battery Care](#battery-care)
+4. [Keyboard Backlight & RGB](#keyboard-backlight--rgb)
+5. [GPU Mode](#gpu-mode)
+6. [Auto-Config on Startup](#auto-config-on-startup)
+7. [CLI Reference](#cli-reference)
+8. [Configuration File (OmenMon.xml)](#configuration-file-omenmonxml)
+9. [Known Issues & Fixes](#known-issues--fixes)
+10. [Reporting Issues](#reporting-issues)
+
+---
+
+## Quick Start
+
+1. Run `OmenMon.exe` — it appears as a tray icon.
+2. Left-click the icon to open the main window.
+3. Right-click the icon for the context menu (fan mode, RGB presets, settings).
+4. To close completely: right-click → **Exit**.
+
+> OmenMon requires **administrator privileges** to access hardware registers.  
+> If the driver fails to load, see [Known Issues](#known-issues--fixes).
+
+---
+
+## Fan Control Modes
+
+### Auto (Default)
+
+Let the BIOS manage fan speed automatically based on the active performance profile.  
+Select **Auto** + a fan mode from the dropdown, then click **Set**.
+
+| Fan Mode    | Hex  | Description                                      |
+|-------------|------|--------------------------------------------------|
+| **Default** | 0x30 | Balanced — matches Windows "Balanced" power plan |
+| **Performance** | 0x31 | Faster fans, higher sustained clocks         |
+| **Cool**    | 0x50 | Prioritises cooling, slightly lower performance  |
+
+> **Tip:** "Performance" and "Cool" are the two main modes you'll use day-to-day.
+
+### Performance
+
+Activates HP's Performance fan profile. Fans spin faster and the system maintains higher sustained boost clocks. Best for gaming or heavy workloads. Equivalent to OMEN Gaming Hub "Performance" mode.
+
+### Cool
+
+Prioritises temperatures over noise. Fans react faster to temperature spikes but performance may be slightly reduced to keep thermals in check.
+
+### Const (Custom Speed)
+
+Set both fans to a fixed speed level (0–55).
+
+1. Select the **Const** radio button.
+2. Use the sliders to set CPU and GPU fan levels.
+3. Click **Set**.
+
+> **Notes:**
+> - Level 0 with both fans = fans off (use only briefly, not for sustained loads).
+> - Level 55 ≈ max hardware speed (~5500 RPM).
+> - The BIOS countdown timer resets every ~15 s automatically while Const is active.
+
+### Fan Programs (Temperature Curves)
+
+Fan programs map **temperature → fan level** automatically as you work.
+
+Define programs in `OmenMon.xml`:
+
+```xml
+<FanPrograms>
+  <Program Name="Gaming">
+    <FanMode>Performance</FanMode>
+    <GpuPower>Maximum</GpuPower>
+    <Level Temperature="0"  Cpu="20" Gpu="20"/>
+    <Level Temperature="50" Cpu="30" Gpu="30"/>
+    <Level Temperature="70" Cpu="45" Gpu="45"/>
+    <Level Temperature="85" Cpu="55" Gpu="55"/>
+  </Program>
+  <Program Name="Quiet">
+    <FanMode>Cool</FanMode>
+    <GpuPower>Reduced</GpuPower>
+    <Level Temperature="0"  Cpu="20" Gpu="20"/>
+    <Level Temperature="60" Cpu="25" Gpu="25"/>
+    <Level Temperature="75" Cpu="35" Gpu="35"/>
+    <Level Temperature="85" Cpu="50" Gpu="50"/>
+  </Program>
+</FanPrograms>
+```
+
+- `Temperature` = trigger point in °C (max of CPU/GPU/PCH)
+- `Cpu` / `Gpu` = fan speed level (0–55)
+- `FanMode` = background performance mode while program runs
+- `GpuPower` = `Maximum` | `Reduced` | `Minimum`
+
+**AutoConfig** can auto-start the default program on launch and switch to an alternate program on battery.
+
+### Max & Off
+
+| Option | Effect |
+|--------|--------|
+| **Max** | Forces both fans to maximum hardware speed |
+| **Off** | Switches fans off — **use with extreme caution**, only when idle/cool |
+
+### Legacy Modes
+
+These are older BIOS values preserved for compatibility. Most users won't need them.
+
+| Mode | Hex | Note |
+|------|-----|------|
+| LegacyDefault | 0x00 | Very old devices |
+| LegacyPerformance | 0x01 | Old performance profile |
+| LegacyCool | 0x02 | Old cool profile |
+| LegacyQuiet | 0x03 | Old quiet profile |
+| LegacyExtreme | 0x04 | Old extreme/boost profile |
+| L0–L8 | various | Internal numeric aliases |
+
+> On modern OMEN laptops (2022+) use **Default**, **Performance**, or **Cool** instead.
+
+---
+
+## Battery Care
+
+OmenMon v1.1.0 supports the HP **Adaptive Battery Extender** (80% charge limit) found on newer OMEN/Victus models, as well as the legacy `Cmd 0x24` interface on older models.
+
+Access via **CLI**:
+
+```
+OmenMon.exe -BatCare On   # Enable 80% charge limit
+OmenMon.exe -BatCare Off  # Charge to 100%
+```
+
+> **Note:** Battery Care requires AC power to toggle on some firmware versions.  
+> If the BIOS rejects the call, try again while plugged in.
+
+---
+
+## Keyboard Backlight & RGB
+
+- **Toggle backlight**: checkbox in main window, or right-click tray → Keyboard → Backlight On/Off.
+- **Color zones**: click a zone on the keyboard image to open the color picker.
+- **Presets**: save/load named color presets via the dropdown.
+- **Cycle presets** with the OMEN key (configure `KeyToggleColorPreset` in XML).
+
+Four-zone keyboard (most models):
+- Zone 0: Right
+- Zone 1: Middle
+- Zone 2: Left
+- Zone 3: WASD
+
+---
+
+## GPU Mode
+
+Right-click tray → **Graphics** to switch between:
+
+| Mode | Description |
+|------|-------------|
+| Hybrid | Integrated + discrete, power-managed |
+| Discrete | Always use dedicated GPU |
+| Optimus | nVidia Optimus mode |
+
+> A **reboot is required** for GPU mode changes to take effect.
+
+---
+
+## Auto-Config on Startup
+
+When `AutoConfig = true` in `OmenMon.xml`:
+
+- Applies GPU power settings on launch.
+- Starts `FanProgramDefault` on AC power.
+- Starts `FanProgramDefaultAlt` on battery.
+- Switches programs automatically when AC is plugged/unplugged.
+
+```xml
+<AutoConfig>true</AutoConfig>
+<FanProgramDefault>Gaming</FanProgramDefault>
+<FanProgramDefaultAlt>Quiet</FanProgramDefaultAlt>
+<GpuPowerDefault>Maximum</GpuPowerDefault>
+```
+
+---
+
+## CLI Reference
+
+Run from Command Prompt (Administrator):
+
+```
+OmenMon.exe [mode] [options]
+```
+
+| Command | Description |
+|---------|-------------|
+| `-Gui` | Start in tray mode (default) |
+| `-BatCare On\|Off` | Toggle battery care (80% limit) |
+| `-FanMode <mode>` | Set fan mode (Default/Performance/Cool/…) |
+| `-FanMax On\|Off` | Toggle maximum fan speed |
+| `-FanOff On\|Off` | Toggle fans off |
+| `-FanLevel <cpu> <gpu>` | Set fan levels (0–55) |
+| `-Prog <name>` | Run a named fan program |
+| `-GpuPower <level>` | Set GPU power (Maximum/Reduced/Minimum) |
+| `-Ec` | Open EC monitor |
+| `-Probe` | Run heuristic hardware scanner |
+
+---
+
+## Configuration File (OmenMon.xml)
+
+Located in the same folder as `OmenMon.exe`. Key settings:
+
+```xml
+<OmenMon>
+  <Config>
+    <AutoConfig>true</AutoConfig>
+    <AutoStartup>true</AutoStartup>
+
+    <!-- BIOS -->
+    <BiosErrorReporting>true</BiosErrorReporting>
+    <BiosHeartbeatPauseOnBattery>true</BiosHeartbeatPauseOnBattery>
+
+    <!-- Fan countdown -->
+    <FanCountdownExtendAlways>false</FanCountdownExtendAlways>
+    <FanCountdownExtendInterval>120</FanCountdownExtendInterval>
+
+    <!-- Fan programs -->
+    <FanProgramDefault>Gaming</FanProgramDefault>
+    <FanProgramDefaultAlt>Quiet</FanProgramDefaultAlt>
+    <FanProgramSuspend>true</FanProgramSuspend>
+
+    <!-- GPU power default -->
+    <GpuPowerDefault>Maximum</GpuPowerDefault>
+  </Config>
+</OmenMon>
+```
+
+### BiosHeartbeatPauseOnBattery
+
+**New in v1.1.1.** When `true` (default), OmenMon pauses its BIOS heartbeat timer while on battery. This prevents a firmware conflict where HP's battery manager can force an unexpected hibernate after extended battery use. Set to `false` only if you experience fan control issues on battery.
+
+---
+
+## Known Issues & Fixes
+
+### Laptop hibernates unexpectedly on battery
+
+**Fixed in v1.1.1.** The BIOS heartbeat (periodic `GetFanCount()` call every 30 s) kept HP's Performance Control session alive on battery, conflicting with HP's battery manager and triggering forced hibernation. `BiosHeartbeatPauseOnBattery = true` (default) fixes this.
+
+**Workaround for older versions:** Set `BiosHeartbeatInterval = 0` in `OmenMon.xml` to disable the heartbeat entirely.
+
+### "Failed to initialize" / Driver not loading
+
+1. Check that Windows Defender is not quarantining `OmenMon.sys`.
+2. Temporarily disable Memory Integrity (Core Isolation) in Windows Security → Device Security.
+3. Run OmenMon as Administrator.
+4. If Windows Defender flags it as `VulnerableDriver:WinNT/Winring0`, see [Security Notes](#security-notes) below.
+
+### Fans stuck at max speed after exiting
+
+Switch to **Auto** mode and click **Set** before closing OmenMon. If already closed, open OmenMon again and switch to Auto.
+
+### Fan control only works on battery / not on AC
+
+Some firmware versions require a specific adapter wattage. If you see "AC Power Low" in OmenMon, the adapter may be under-rated (e.g., 200 W instead of 230 W). Use the original or a compatible adapter.
+
+### CPU temperature not displayed
+
+Your device's EC register layout may differ from the default. Run **Contribute Hardware Data** from the tray menu to help identify the correct registers for your model.
+
+### CPU temperature not shown or wrong zone count (RGB)
+
+Known on some OMEN Max 16 / non-standard models. Use `Probe` mode to identify your EC layout. See [wiki/Contributing-Hardware-Data.md](wiki/Contributing-Hardware-Data.md).
+
+### BSOD / Memory integrity conflicts
+
+OmenMon uses `WinRing0.sys` for EC access. If BSOD occurs:
+- Do not use older versions of OmenMon (< v1.0) that bundle an unpatched `WinRing0.sys`.
+- v1.x uses a patched driver. If BSODs persist, disable Memory Integrity temporarily during use.
+
+### Security Notes
+
+`WinRing0.sys` has CVE-2020-14979 (local privilege escalation). OmenMon v1.x bundles a patched version. Windows Defender may still flag it. Adding an exclusion for the OmenMon folder resolves false positives. Never download OmenMon from unofficial sources.
+
+---
+
+## Reporting Issues
+
+1. Open OmenMon → right-click tray → **Contribute Hardware Data** (attaches your EC register layout).
+2. Run `OmenMon.exe -Probe` and copy the output.
+3. File a bug at: **https://github.com/OmenMon/OmenMon/issues**
+
+Include:
+- Your HP model (e.g., `HP OMEN 16-b0075ng`)
+- Windows version
+- OmenMon version
+- Steps to reproduce
+- Probe output (if relevant)

--- a/INSTRUCTION.md
+++ b/INSTRUCTION.md
@@ -300,7 +300,7 @@ OmenMon uses `WinRing0.sys` for EC access. If BSOD occurs:
 
 1. Open OmenMon → right-click tray → **Contribute Hardware Data** (attaches your EC register layout).
 2. Run `OmenMon.exe -Probe` and copy the output.
-3. File a bug at: **https://github.com/OmenMon/OmenMon/issues**
+3. File a bug at: **https://github.com/seakyy/OmenMon-Reborn/issues**
 
 Include:
 - Your HP model (e.g., `HP OMEN 16-b0075ng`)

--- a/Library/Config.cs
+++ b/Library/Config.cs
@@ -150,6 +150,9 @@ namespace OmenMon.Library {
                     if(GetBool(xml, XmlPrefix + "BiosErrorReporting", out flag))
                         BiosErrorReporting = flag;
 
+                    if(GetBool(xml, XmlPrefix + "BiosHeartbeatPauseOnBattery", out flag))
+                        BiosHeartbeatPauseOnBattery = flag;
+
                     if(GetWord(xml, XmlPrefix + "EcFailLimit", out value))
                         EcFailLimit = value;
 

--- a/Library/ConfigData.cs
+++ b/Library/ConfigData.cs
@@ -39,6 +39,11 @@ namespace OmenMon.Library {
         // Set to 0 to disable
         public static int BiosHeartbeatInterval = 30000;
 
+        // Pause BIOS heartbeat on battery power to prevent HP firmware from forcing hibernate.
+        // The heartbeat keeps HP's "Performance Control" session alive; on battery this conflicts
+        // with the BIOS battery-manager and can trigger unexpected hibernation after extended use.
+        public static bool BiosHeartbeatPauseOnBattery = true;
+
         // Color presets (overriden at runtime if found in the configuration file)
         public static SortedDictionary<string, BiosData.ColorTable> ColorPreset =
             new SortedDictionary<string, BiosData.ColorTable>() {

--- a/OmenMon.xml
+++ b/OmenMon.xml
@@ -1,269 +1,304 @@
-<?xml version="1.0" encoding="utf-8"?> 
+<?xml version="1.0" encoding="utf-8"?>
 <OmenMon>
-
     <!--
-
       //\\   OmenMon: Hardware Monitoring & Control Utility
      //  \\  Configuration Settings XML File
          //  https://omenmon.github.io/
-
     -->
-
     <!-- Note: comments under child nodes such as <ColorPresets> and <FanPrograms>
          will be overwritten when the file is automatically generated upon save -->
-
     <Config>
-
         <!-- Automatically apply settings on start -->
         <AutoConfig>false</AutoConfig>
-
         <!-- Automatically start up with Windows -->
         <AutoStartup>true</AutoStartup>
-
         <!-- Ignore BIOS errors if false (for not fully compatible devices) -->
         <BiosErrorReporting>true</BiosErrorReporting>
-
         <!-- Color Backlight -->
-
         <!-- Note: two default entries are hard-coded in the application
              and will appear if there is nothing else to show instead -->
         <ColorPresets>
-            <Preset Name="DefaultOem">0F84FA:710FFA:F9350F:FAAC0F</Preset>
-            <Preset Name="DefaultApp">0080FF:00FF00:00FF00:FFFFFF</Preset>
             <Preset Name="All Amber">FF8800:FF8800:FF8800:FF8800</Preset>
             <Preset Name="All White">FFFFFF:FFFFFF:FFFFFF:FFFFFF</Preset>
             <Preset Name="Cyan Magenta Yellow">FFFF00:FF0080:3AE5E7:FFFF00</Preset>
+            <Preset Name="DefaultApp">0080FF:00FF00:00FF00:FFFFFF</Preset>
+            <Preset Name="DefaultOem">0F84FA:710FFA:F9350F:FAAC0F</Preset>
             <Preset Name="Red Green Blue">0000FF:00FF00:FF0000:FFFFFF</Preset>
         </ColorPresets>
-
         <!-- Embedded Controller -->
-
         <!-- Maximum number of failed attempts waiting to read -->
         <EcFailLimit>15</EcFailLimit>
-
         <!-- Embedded Controller monitoring interval [ms]
              (applies to command-line mode -EcMon context) -->
         <EcMonInterval>1000</EcMonInterval>
-
         <!-- How long before bailing out trying to get a mutex [ms] -->
         <EcMutexTimeout>200</EcMutexTimeout>
-
         <!-- Maximum number of read or write attempts -->
         <EcRetryLimit>3</EcRetryLimit>
-
         <!-- Iterations before waiting fails each time -->
         <EcWaitLimit>30</EcWaitLimit>
-
         <!-- Fan Control -->
-
         <!-- Fan countdown will always be continually extended, even
              with no fan program running, no constant-speed button
              selected, and the main window hidden, until exit -->
         <FanCountdownExtendAlways>false</FanCountdownExtendAlways>
-
         <!-- Fan countdown timer will be extended by this value [s] -->
         <FanCountdownExtendInterval>120</FanCountdownExtendInterval>
-
-        <!-- Fan countdown extension threshold [s]
-             If the constant-speed button is selected (even if not
-             necessarily running at a constant-speed setting), the
-             fan countdown value will be extended when it reaches
-             less than the value for:
-             UpdateMonitorInterval + FanCountdownExtendThreshold
-             In fan program mode, or when FanCountdownExtendAlways
-             is enabled, the threshold is:
-             UpdateProgramInterval + FanCountdownExtendThreshold -->
+        <!-- Fan countdown extension threshold [s] -->
         <FanCountdownExtendThreshold>5</FanCountdownExtendThreshold>
-
-        <!-- Minimum and maximum fan level thresholds [krpm]
-             (for trackbar constant-speed level adjustment,
-             lowest setting will be interpreted as 0) -->
+        <!-- Minimum and maximum fan level thresholds [krpm] -->
         <FanLevelMax>55</FanLevelMax>
         <FanLevelMin>20</FanLevelMin>
-
-        <!-- Before setting fan levels, set manual
-             fan mode first using the Embedded Controller -->
+        <!-- Before setting fan levels, set manual fan mode first using the Embedded Controller -->
         <FanLevelNeedManual>false</FanLevelNeedManual>
-
-        <!-- Use the Embedded Controller instead
-             of a BIOS call for fan-level setting -->
+        <!-- Use the Embedded Controller instead of a BIOS call for fan-level setting -->
         <FanLevelUseEc>false</FanLevelUseEc>
-
-        <!-- Default fan program, which might be loaded on startup
-             (depending on the Autoconfig setting) -->
-        <FanProgramDefault>Power</FanProgramDefault>
-
-        <!-- Default alternate fan program to switch to
-             if no longer on AC power (i.e. on battery) -->
+        <!-- Default fan program, which might be loaded on startup -->
+        <FanProgramDefault>Default</FanProgramDefault>
+        <!-- Default alternate fan program to switch to if no longer on AC power -->
         <FanProgramDefaultAlt>Silent</FanProgramDefaultAlt>
-
-        <!-- Check first (using the EC) if the fan mode is not set already
-             before setting it (using a BIOS WMI call) during a fan program
-             (if false, makes three EC operations fewer every UpdateProgramInterval,
-             at the cost of one more WMI BIOS call: can be used to reduce EC load) -->
+        <!-- Check first (using the EC) if the fan mode is not set already -->
         <FanProgramModeCheckFirst>false</FanProgramModeCheckFirst>
-
-        <!-- If true, fan program will be suspended whenever the system enters low-power mode
-             such as sleep, standby or hibernation, to be automatically re-enabled upon resume -->
+        <!-- Suspend fan program whenever the system enters low-power mode -->
         <FanProgramSuspend>true</FanProgramSuspend>
-
         <!-- Fan program definitions
-             Curve visualization: https://www.desmos.com/calculator/6vfpghtud0
-                                  (editable initial data for the Power program) -->
+             Curve visualization: https://www.desmos.com/calculator/6vfpghtud0 -->
         <FanPrograms>
             <Program Name="Power">
                 <FanMode>Performance</FanMode>
-                <GpuPower>Maximum</GpuPower>
-                <Level Temperature="00"><Cpu>00</Cpu><Gpu>00</Gpu></Level>
-                <Level Temperature="36"><Cpu>21</Cpu><Gpu>00</Gpu></Level>
-                <Level Temperature="39"><Cpu>22</Cpu><Gpu>22</Gpu></Level>
-                <Level Temperature="42"><Cpu>23</Cpu><Gpu>24</Gpu></Level>
-                <Level Temperature="45"><Cpu>24</Cpu><Gpu>26</Gpu></Level>
-                <Level Temperature="48"><Cpu>25</Cpu><Gpu>27</Gpu></Level>
-                <Level Temperature="51"><Cpu>26</Cpu><Gpu>29</Gpu></Level>
-                <Level Temperature="54"><Cpu>28</Cpu><Gpu>31</Gpu></Level>
-                <Level Temperature="57"><Cpu>30</Cpu><Gpu>33</Gpu></Level>
-                <Level Temperature="60"><Cpu>32</Cpu><Gpu>35</Gpu></Level>
-                <Level Temperature="63"><Cpu>34</Cpu><Gpu>37</Gpu></Level>
-                <Level Temperature="66"><Cpu>36</Cpu><Gpu>40</Gpu></Level>
-                <Level Temperature="69"><Cpu>38</Cpu><Gpu>43</Gpu></Level>
-                <Level Temperature="72"><Cpu>41</Cpu><Gpu>46</Gpu></Level>
-                <Level Temperature="75"><Cpu>44</Cpu><Gpu>49</Gpu></Level>
-                <Level Temperature="78"><Cpu>47</Cpu><Gpu>52</Gpu></Level>
-                <Level Temperature="81"><Cpu>50</Cpu><Gpu>55</Gpu></Level>
-                <Level Temperature="84"><Cpu>55</Cpu><Gpu>57</Gpu></Level>
+                <GpuPower>Default</GpuPower>
+                <Level Temperature="00">
+                    <Cpu>00</Cpu>
+                    <Gpu>00</Gpu>
+                </Level>
+                <Level Temperature="36">
+                    <Cpu>21</Cpu>
+                    <Gpu>00</Gpu>
+                </Level>
+                <Level Temperature="39">
+                    <Cpu>22</Cpu>
+                    <Gpu>22</Gpu>
+                </Level>
+                <Level Temperature="42">
+                    <Cpu>23</Cpu>
+                    <Gpu>24</Gpu>
+                </Level>
+                <Level Temperature="45">
+                    <Cpu>24</Cpu>
+                    <Gpu>26</Gpu>
+                </Level>
+                <Level Temperature="48">
+                    <Cpu>25</Cpu>
+                    <Gpu>27</Gpu>
+                </Level>
+                <Level Temperature="51">
+                    <Cpu>26</Cpu>
+                    <Gpu>29</Gpu>
+                </Level>
+                <Level Temperature="54">
+                    <Cpu>28</Cpu>
+                    <Gpu>31</Gpu>
+                </Level>
+                <Level Temperature="57">
+                    <Cpu>30</Cpu>
+                    <Gpu>33</Gpu>
+                </Level>
+                <Level Temperature="60">
+                    <Cpu>32</Cpu>
+                    <Gpu>35</Gpu>
+                </Level>
+                <Level Temperature="63">
+                    <Cpu>34</Cpu>
+                    <Gpu>37</Gpu>
+                </Level>
+                <Level Temperature="66">
+                    <Cpu>36</Cpu>
+                    <Gpu>40</Gpu>
+                </Level>
+                <Level Temperature="69">
+                    <Cpu>38</Cpu>
+                    <Gpu>43</Gpu>
+                </Level>
+                <Level Temperature="72">
+                    <Cpu>41</Cpu>
+                    <Gpu>46</Gpu>
+                </Level>
+                <Level Temperature="75">
+                    <Cpu>44</Cpu>
+                    <Gpu>49</Gpu>
+                </Level>
+                <Level Temperature="78">
+                    <Cpu>47</Cpu>
+                    <Gpu>52</Gpu>
+                </Level>
+                <Level Temperature="81">
+                    <Cpu>50</Cpu>
+                    <Gpu>55</Gpu>
+                </Level>
+                <Level Temperature="84">
+                    <Cpu>55</Cpu>
+                    <Gpu>57</Gpu>
+                </Level>
             </Program>
             <Program Name="Silent">
                 <FanMode>Default</FanMode>
                 <GpuPower>Minimum</GpuPower>
-                <Level Temperature="00"><Cpu>21</Cpu><Gpu>00</Gpu></Level>
-                <Level Temperature="50"><Cpu>25</Cpu><Gpu>00</Gpu></Level>
-                <Level Temperature="55"><Cpu>25</Cpu><Gpu>25</Gpu></Level>
-                <Level Temperature="60"><Cpu>30</Cpu><Gpu>30</Gpu></Level>
-                <Level Temperature="65"><Cpu>35</Cpu><Gpu>35</Gpu></Level>
-                <Level Temperature="70"><Cpu>40</Cpu><Gpu>40</Gpu></Level>
-                <Level Temperature="75"><Cpu>45</Cpu><Gpu>45</Gpu></Level>
-                <Level Temperature="80"><Cpu>50</Cpu><Gpu>50</Gpu></Level>
-                <Level Temperature="85"><Cpu>55</Cpu><Gpu>57</Gpu></Level>
+                <Level Temperature="00">
+                    <Cpu>21</Cpu>
+                    <Gpu>00</Gpu>
+                </Level>
+                <Level Temperature="50">
+                    <Cpu>25</Cpu>
+                    <Gpu>00</Gpu>
+                </Level>
+                <Level Temperature="55">
+                    <Cpu>25</Cpu>
+                    <Gpu>25</Gpu>
+                </Level>
+                <Level Temperature="60">
+                    <Cpu>30</Cpu>
+                    <Gpu>30</Gpu>
+                </Level>
+                <Level Temperature="65">
+                    <Cpu>35</Cpu>
+                    <Gpu>35</Gpu>
+                </Level>
+                <Level Temperature="70">
+                    <Cpu>40</Cpu>
+                    <Gpu>40</Gpu>
+                </Level>
+                <Level Temperature="75">
+                    <Cpu>45</Cpu>
+                    <Gpu>45</Gpu>
+                </Level>
+                <Level Temperature="80">
+                    <Cpu>50</Cpu>
+                    <Gpu>50</Gpu>
+                </Level>
+                <Level Temperature="85">
+                    <Cpu>55</Cpu>
+                    <Gpu>57</Gpu>
+                </Level>
             </Program>
         </FanPrograms>
-
         <!-- GPU -->
-
-        <!-- Default GPU power settings, which might be loaded on startup
-             (depending on the Autoconfig setting) -->
-        <GpuPowerDefault>Maximum</GpuPowerDefault>
-
-        <!-- The wait before setting the GPU power for the 2nd time [ms]
-             (sometimes the settings do not take effect the first time,
-             so the command is sent twice but the second time only after
-             the specified period has passed) -->
+        <!-- Default GPU power settings -->
+        <GpuPowerDefault>Default</GpuPowerDefault>
+        <!-- The wait before setting the GPU power for the 2nd time [ms] -->
         <GpuPowerSetInterval>200</GpuPowerSetInterval>
-
         <!-- Graphical User Interface -->
-
-        <!-- Whether closing the window closes the whole application -->
         <GuiCloseWindowExit>false</GuiCloseWindowExit>
-
-        <!-- Whether to resize the main window if DPI changes -->
         <GuiDpiChangeResize>false</GuiDpiChangeResize>
-
-        <!-- Whether to use a dynamic notification icon by default
-             (icon text shows current temperature) -->
         <GuiDynamicIcon>true</GuiDynamicIcon>
-
-        <!-- Whether the dynamic icon has a dynamic background or not
-             (background is warm in performance mode, cool otherwise) -->
         <GuiDynamicIconHasBackground>true</GuiDynamicIconHasBackground>
-
-        <!-- Whether the main window stays on top of all other windows -->
-        <GuiStayOnTop>false</GuiStayOnTop>
-
-        <!-- Override System Information font size (leave 0 for the default) -->
+        <GuiStayOnTop>true</GuiStayOnTop>
         <GuiSysInfoFontSize>0</GuiSysInfoFontSize>
-
-        <!-- How long to show a tip in the notification area for [ms]
-             (0 to disable entirely; the default setting of 30000, or 30 s,
-              is scaled down to a couple of seconds by the operating system) -->
         <GuiTipDuration>30000</GuiTipDuration>
-
         <!-- Omen Key -->
-
-        <!-- Custom Omen key action -->
         <KeyCustomAction>
             <Enabled>false</Enabled>
-            <!-- This example command will turn off the display
-                 and keyboard backlight while the laptop keeps running -->
             <ExecCmd>cmd.exe</ExecCmd>
             <ExecArgs>/c start /min "" powershell -WindowStyle Hidden (Add-Type '[DllImport(\"user32.dll\")] public static extern int SendMessage(int hWnd, int hMsg, int wParam, int lParam);' -Name User32 -PassThru)::SendMessage(-1, 0x0112, 0xF170, 2) ^| Out-Null</ExecArgs>
             <Minimized>true</Minimized>
         </KeyCustomAction>
+        
+        <!-- Cycle through keyboard color presets on Omen key press -->
+        <!-- Takes priority over KeyToggleFanProgram and KeyCustomAction -->
+        <KeyToggleColorPreset>true</KeyToggleColorPreset>
+        
+        <!-- Suppress the balloon tip notification when cycling presets -->
+        <KeyToggleColorPresetSilent>false</KeyToggleColorPresetSilent>
 
-        <!-- Use the Omen key to control fan program
-             (as long as KeyCustomAction is set to false) -->
         <KeyToggleFanProgram>false</KeyToggleFanProgram>
-
-        <!-- If true, Omen key cycles through all fan programs,
-             instead of toggling the default fan program on and off -->
         <KeyToggleFanProgramCycleAll>true</KeyToggleFanProgramCycleAll>
-
-        <!-- Show window upon first Omen key press (if not shown already),
-             before using subsequent keypresses to control fan program -->
         <KeyToggleFanProgramShowGuiFirst>true</KeyToggleFanProgramShowGuiFirst>
-
-        <!-- Do not show a balloon tip notification when changing programs -->
         <KeyToggleFanProgramSilent>false</KeyToggleFanProgramSilent>
-
         <!-- Preset Settings -->
-
-        <!-- High display refresh rate preset value [Hz] -->
         <PresetRefreshRateHigh>165</PresetRefreshRateHigh>
-
-        <!-- Standard display refresh rate preset value [Hz] -->
         <PresetRefreshRateLow>60</PresetRefreshRateLow>
-
         <!-- Temperature Sensors -->
-
-        <!-- Note: nine default sensors are hard-coded in the application
-             and will be used instead if none are defined here -->
+        <!-- Note: Unreliable EC sensors (TNT2-TNT5) and BIOS are disabled for fan curves by default to prevent 100% Fan Bugs -->
         <Temperature>
             <Sensor Name="CPUT" Source="EC" />
             <Sensor Name="GPTM" Source="EC" />
             <Sensor Name="BIOS" Source="BIOS" Use="false" />
             <Sensor Name="RTMP" Source="EC" />
             <Sensor Name="TMP1" Source="EC" />
-            <Sensor Name="TNT2" Source="EC" />
-            <Sensor Name="TNT3" Source="EC" />
-            <Sensor Name="TNT4" Source="EC" />
-            <Sensor Name="TNT5" Source="EC" />
+            <Sensor Name="TNT2" Source="EC" Use="false" />
+            <Sensor Name="TNT3" Source="EC" Use="false" />
+            <Sensor Name="TNT4" Source="EC" Use="false" />
+            <Sensor Name="TNT5" Source="EC" Use="false" />
         </Temperature>
-
+        <!-- Model Database -->
+        <!-- The application reads EC register mappings from here. If a model is not listed, the Heuristic Scanner will auto-configure it. -->
+        <Models>
+            <Model ProductId="8A4C" DisplayName="Omen 16 (2022, i9-12900H)">
+                <FanLevelReg0>52</FanLevelReg0>
+                <FanLevelReg1>53</FanLevelReg1>
+                <FanRateReadReg0>46</FanRateReadReg0>
+                <FanRateReadReg1>47</FanRateReadReg1>
+                <FanRateWriteReg0>58</FanRateWriteReg0>
+                <FanRateWriteReg1>59</FanRateWriteReg1>
+                <FanSpeedReg0>176</FanSpeedReg0>
+                <FanSpeedReg1>178</FanSpeedReg1>
+                <CountdownReg>99</CountdownReg>
+                <ManualReg>98</ManualReg>
+                <ModeReg>149</ModeReg>
+                <SwitchReg>244</SwitchReg>
+            </Model>
+            <Model ProductId="8A4D" DisplayName="Omen 16 (2022, k0xxx)">
+                <FanLevelReg0>52</FanLevelReg0>
+                <FanLevelReg1>53</FanLevelReg1>
+                <FanRateReadReg0>46</FanRateReadReg0>
+                <FanRateReadReg1>47</FanRateReadReg1>
+                <FanRateWriteReg0>58</FanRateWriteReg0>
+                <FanRateWriteReg1>59</FanRateWriteReg1>
+                <FanSpeedReg0>176</FanSpeedReg0>
+                <FanSpeedReg1>178</FanSpeedReg1>
+                <CountdownReg>99</CountdownReg>
+                <ManualReg>98</ManualReg>
+                <ModeReg>149</ModeReg>
+                <SwitchReg>244</SwitchReg>
+            </Model>
+            <!-- 8BBE: HP Victus 16 R0053NT (2023) — fan level regs at 0x11/0x12, confirmed via probe EC[0x11]=BIOS CPU level -->
+            <Model ProductId="8BBE" DisplayName="HP Victus 16 (2023, R0053NT)">
+                <FanLevelReg0>17</FanLevelReg0>
+                <FanLevelReg1>18</FanLevelReg1>
+                <FanRateReadReg0>46</FanRateReadReg0>
+                <FanRateReadReg1>47</FanRateReadReg1>
+                <FanRateWriteReg0>58</FanRateWriteReg0>
+                <FanRateWriteReg1>59</FanRateWriteReg1>
+                <FanSpeedReg0>176</FanSpeedReg0>
+                <FanSpeedReg1>178</FanSpeedReg1>
+                <CountdownReg>99</CountdownReg>
+                <ManualReg>98</ManualReg>
+                <ModeReg>149</ModeReg>
+                <SwitchReg>244</SwitchReg>
+            </Model>
+            <!-- 8BAB: HP Omen 16 (2025) — same fan level register layout as 8BBE, confirmed via probe EC[0x11]=BIOS CPU level -->
+            <Model ProductId="8BAB" DisplayName="HP Omen 16 (2025)">
+                <FanLevelReg0>17</FanLevelReg0>
+                <FanLevelReg1>18</FanLevelReg1>
+                <FanRateReadReg0>46</FanRateReadReg0>
+                <FanRateReadReg1>47</FanRateReadReg1>
+                <FanRateWriteReg0>58</FanRateWriteReg0>
+                <FanRateWriteReg1>59</FanRateWriteReg1>
+                <FanSpeedReg0>176</FanSpeedReg0>
+                <FanSpeedReg1>178</FanSpeedReg1>
+                <CountdownReg>99</CountdownReg>
+                <ManualReg>98</ManualReg>
+                <ModeReg>149</ModeReg>
+                <SwitchReg>244</SwitchReg>
+            </Model>
+        </Models>
         <!-- Update Interval -->
-
-        <!-- How often the dynamic notification icon is updated [s] -->
         <UpdateIconInterval>3</UpdateIconInterval>
-
-        <!-- How often the monitoring data on the main form is updated [s] -->
         <UpdateMonitorInterval>3</UpdateMonitorInterval>
-
-        <!-- How often the fan program is updated (if running) [s] -->
         <UpdateProgramInterval>15</UpdateProgramInterval>
-
     </Config>
-
     <!-- Localizable Messages -->
-
-    <!-- Any of the application's messages can be redefined,
-         for example translated to another language -->
-
     <Messages>
-
-        <!-- The following two strings will optionally show translator credit
-             (these are empty by default, and nothing is shown) -->
-
         <!-- <String Key="CliTranslated">Translated to [Language] by [Author]</String> -->
         <!-- <String Key="GuiTranslated">Translated by [Author]</String> -->
-
     </Messages>
-
 </OmenMon>

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,13 +1,19 @@
-# OmenMon-Reborn — Developer Wiki
+# OmenMon-Reborn — Wiki
 
 **OmenMon-Reborn** is a fork of [OmenMon](https://github.com/OmenMon/OmenMon) by Piotr Szczepański.  
-Fork maintained by [@seakyy](https://github.com/seakyy). Current release: **1.0.0-reborn** (2026-04-30).
+Fork maintained by [@seakyy](https://github.com/seakyy). Current release: **v1.1.1-reborn** (2026-05-04).
 
 The primary goal of this fork is to replace the hardcoded 2023 EC register layout with a dynamic, XML-driven model database, and to make unknown devices self-configuring through a safe read-only heuristic scan.
 
 ---
 
-## Pages
+## User Documentation
+
+**New to OmenMon? Start here:** [INSTRUCTION.md](../INSTRUCTION.md) — covers fan modes, fan programs, battery care, RGB, CLI, and known issues.
+
+---
+
+## Developer Pages
 
 | Page | What it covers |
 |------|----------------|


### PR DESCRIPTION
- Fixed critical bug where the BIOS heartbeat timer (Cmd 0x10) caused HP's battery manager to force unexpected hibernation on battery power.
- Added 'BiosHeartbeatPauseOnBattery' config setting (defaults to true) to pause the timer when AC power is disconnected.
- Added custom EC register layouts for HP models 8BBE (Victus 16) and 8BAB (Omen 16) to OmenMon.xml.
- Created comprehensive user documentation (INSTRUCTION.md) covering fan modes, custom curves, battery care, and RGB control.
- Updated CHANGELOG.md and Wiki Home with v1.1.1 release notes and doc links.