### PR TITLE
docs: post-v1.4.0 follow-up — badges, SECURITY policy, 8C77 row

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # OmenMon-Reborn
 
 <p align="center">
+  <a href="https://github.com/seakyy/OmenMon-Reborn/releases/latest"><img src="https://img.shields.io/github/v/release/seakyy/OmenMon-Reborn?color=brightgreen&label=Latest%20Release" alt="Latest release"></a>
+  <a href="https://github.com/seakyy/OmenMon-Reborn/releases"><img src="https://img.shields.io/github/downloads/seakyy/OmenMon-Reborn/total?color=blue&label=Downloads" alt="Downloads"></a>
+  <a href="https://github.com/seakyy/OmenMon-Reborn/stargazers"><img src="https://img.shields.io/github/stars/seakyy/OmenMon-Reborn?style=social" alt="Stars"></a>
+</p>
+
+<p align="center">
   <a href="https://buymeacoffee.com/seakyy"><img src="https://img.shields.io/badge/Buy%20me%20a%20coffee-seakyy-FFDD00?style=for-the-badge&logo=buy-me-a-coffee&logoColor=black" alt="Buy Me a Coffee"></a>
 </p>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,78 @@
+# Security Policy
+
+## Supported Versions
+
+Only the **latest released version** of OmenMon-Reborn receives security
+updates. Older releases are not patched — please upgrade before reporting
+any issue.
+
+| Version          | Supported          |
+|------------------|--------------------|
+| `1.4.x-reborn`   | :white_check_mark: |
+| `< 1.4.0-reborn` | :x:                |
+
+## Reporting a Vulnerability
+
+OmenMon-Reborn interfaces with kernel-mode drivers and HP's low-level
+Embedded Controller, so security issues here can have real impact —
+arbitrary EC writes, kernel-mode read primitives, privilege escalation
+chains. **Please do not report security vulnerabilities through public
+GitHub issues, discussions, or pull requests.**
+
+### How to report privately
+
+You have two options:
+
+1. **GitHub private advisory** (preferred): use the repository's
+   ["Report a vulnerability"](https://github.com/seakyy/OmenMon-Reborn/security/advisories/new)
+   button under the Security tab. This creates a private channel between
+   you and the maintainer that GitHub can later convert into a published
+   advisory once a fix is out.
+2. **Discord**: DM **`vsun`** (`835146076016607323`). Please include the
+   word "security" in your first message so it's not lost in the general
+   support flow.
+
+### What to include in your report
+
+A useful report contains, at minimum:
+
+- The OmenMon-Reborn version (`OmenMon.exe -h` shows it, or check the
+  tray menu's "About" entry).
+- Your Windows version (`winver`) and whether HVCI / Memory Integrity is
+  on.
+- Whether PawnIO is installed and what version (`OmenMon.exe -Diag`
+  output covers all of this in one paste — see below).
+- A description of the issue, ideally with a reproducer.
+- The impact you believe it has (information disclosure, privilege
+  escalation, denial of service, etc.).
+
+For non-trivial reports, running `OmenMon.exe -Diag` and attaching the
+resulting `OmenMon-Diag-*.md` file gives the maintainer everything
+needed to triage without back-and-forth.
+
+### What to expect
+
+- Acknowledgement within a few days (this is a hobby project — I don't
+  promise 24-hour response times, but I do read every message).
+- A coordinated disclosure timeline once severity is established.
+- Credit in the resulting release notes if you'd like it (anonymous
+  reports are also welcome).
+
+### Out of scope
+
+Things that are **not** security issues for this project:
+
+- Windows Defender flagging older `1.3.x` releases — that's the WinRing0
+  driver, and it's fixed in `1.4.0`+ by switching to the Microsoft-signed
+  PawnIO driver. Just upgrade.
+- Bugs that require an already-administrative attacker to exploit — they
+  already have everything OmenMon could give them.
+- Crashes that produce a stack trace but no exploitable state. Please
+  file those as regular bug reports.
+
+## Scope
+
+This policy covers the `OmenMon-Reborn` codebase and the embedded
+`Resources/LpcACPIEC.bin` PawnIO module redistribution. Issues in the
+upstream PawnIO driver itself should be reported to
+[namazso/PawnIO](https://github.com/namazso/PawnIO/security) directly.

--- a/wiki/Model-Database.md
+++ b/wiki/Model-Database.md
@@ -101,6 +101,7 @@ The following IDs have been reported in upstream issues. Entries marked ✅ have
 | `8DD0` | Omen (2025) | ✅ 2023+ layout, RPM at `0xB0`/`0xB2` (issue #26, false-positive auto-cal mitigated via built-in `AutoCal.Prime` in v1.4.0 — issue #33) |
 | `8D26` | Omen 16-ap0007ns (2026) | ✅ 2023+ layout, RPM at `0xB0`/`0xB2` (issue #52) |
 | `88EB` | Victus 16 (2021) | ✅ 2023+ layout, RPM at `0xB0`/`0xB2` (issue #48) |
+| `8C77` | Omen 16-wf1012nl (2024) — single-fan SKU | ⚠️ Sidecar-resolved via the Auto-Calibration Wizard (issue #50). CPU fan at `EC[0xD2]` (`PeriodEncoded8`, idle ≈ `0xB2`, max ≈ `0x11`). No GPU fan detected — likely a physically single-fan chassis, not a missed register. Not yet added to the shipped native database: waiting on a second `8C77` owner to confirm the layout is consistent across the SKU (HP recycles product IDs across regional variants). Owners can install OmenMon as normal — the wizard's `OmenMon-AutoCal.xml` keeps the install working out of the box. |
 | `8A3E` | Victus 15 fb0102la | ❓ |
 | `8748` | Omen 17 cb1046nr (2021) | ❓ |
 | `88FE` | Omen 17 ck0xxx (2020) | ❓ |


### PR DESCRIPTION
- README.md: add three shields.io badges (latest release, total downloads, star count) to the top header. Gives first-time visitors instant social proof that the project is alive, ships releases, and has actual users — highest-value low-effort change given the recent traffic spike.
- SECURITY.md: create. Unlocks GitHub's "Security policy" badge, sets up a private-disclosure channel (private advisory + Discord DM to vsun / 835146076016607323), states supported version range, defines scope vs. out-of-scope so the maintainer doesn't drown in "Defender flags v1.3.x" reports.
- wiki/Model-Database.md: add 8C77 (Omen 16-wf1012nl, single-fan) row with the auto-cal findings from issue #50 and a clear "sidecar- resolved, waiting on a second confirmation before going native" note. Documents the SKU naming so the next maintainer doesn't repeat my "Victus 15" mis-attribution from the issue thread.