### PR TITLE
docs: note CI build-number override in RELEASING.md and Version.cs

### DIFF
--- a/All/Version.cs
+++ b/All/Version.cs
@@ -4,8 +4,11 @@
 
 using System.Reflection;
 
-// Project version metadata is set dynamically
-// These are just the defaults to be overriden
+// Project version metadata is set dynamically.
+// These are just the defaults used for local builds — CI overrides the
+// 4th segment of AssemblyVersion with the BUILD_NUMBER repo variable
+// (auto-incremented by .github/workflows/build_bump.yml), so shipped
+// binaries appear as X.Y.Z.<build#> rather than X.Y.Z.0.
 [assembly: AssemblyVersion("1.4.0.0")]
 [assembly: AssemblyFileVersion("1.4.0.0")]
 [assembly: AssemblyInformationalVersion("1.4.0-reborn")]

--- a/All/Version.cs
+++ b/All/Version.cs
@@ -5,10 +5,13 @@
 using System.Reflection;
 
 // Project version metadata is set dynamically.
-// These are just the defaults used for local builds — CI overrides the
-// 4th segment of AssemblyVersion with the BUILD_NUMBER repo variable
-// (auto-incremented by .github/workflows/build_bump.yml), so shipped
-// binaries appear as X.Y.Z.<build#> rather than X.Y.Z.0.
+// These are just the defaults used for local builds. In CI the AddVersion
+// target in OmenMon.csproj rewrites this file: AssemblyVersion is stamped
+// with only the first three segments (X.Y.Z, .NET pads to X.Y.Z.0 — kept
+// stable to avoid breaking assembly binding), while AssemblyFileVersion
+// gets the full four segments including BUILD_NUMBER (auto-incremented by
+// .github/workflows/build_bump.yml), so shipped binaries appear as
+// X.Y.Z.<build#> in File Explorer / Get-FileHash properties.
 [assembly: AssemblyVersion("1.4.0.0")]
 [assembly: AssemblyFileVersion("1.4.0.0")]
 [assembly: AssemblyInformationalVersion("1.4.0-reborn")]

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -92,11 +92,19 @@ Three files need to know about the new version. Keep them in sync.
 The CI workflow can override `AssemblyVersion` from the build inputs but the
 local `Rebuild` you do in step 2 uses these defaults. Keep them honest.
 
-> **Note:** CI overrides the 4th segment with the `BUILD_NUMBER` repo
-> variable (auto-incremented by `build_bump.yml` via `VARIABLE_WRITE_TOKEN`),
-> so the published `AssemblyVersion` will read as `X.Y.Z.<build#>` (e.g.
-> `1.5.0.42`) rather than the `X.Y.Z.0` you see locally. The first three
-> segments are what you bump here; the fourth is just a CI counter.
+> **Note:** In CI the `AddVersion` target in `OmenMon.csproj` rewrites this
+> file before compile. The split is deliberate:
+>
+> - `AssemblyVersion` keeps only the first three segments (X.Y.Z, .NET pads
+>   to X.Y.Z.0). Stable — changing it would break assembly binding.
+> - `AssemblyFileVersion` gets the full four segments, where the 4th is the
+>   `BUILD_NUMBER` repo variable (auto-incremented by `build_bump.yml` via
+>   `VARIABLE_WRITE_TOKEN`).
+>
+> So a shipped binary's *file* version reads as `X.Y.Z.<build#>` (e.g.
+> `1.5.0.42`) in Windows file properties / `Get-FileHash` output, while its
+> *assembly* version stays at `X.Y.Z.0`. The first three segments are what
+> you bump here; the fourth is just a CI counter on `AssemblyFileVersion`.
 
 ### `wiki/Home.md`
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -92,6 +92,12 @@ Three files need to know about the new version. Keep them in sync.
 The CI workflow can override `AssemblyVersion` from the build inputs but the
 local `Rebuild` you do in step 2 uses these defaults. Keep them honest.
 
+> **Note:** CI overrides the 4th segment with the `BUILD_NUMBER` repo
+> variable (auto-incremented by `build_bump.yml` via `VARIABLE_WRITE_TOKEN`),
+> so the published `AssemblyVersion` will read as `X.Y.Z.<build#>` (e.g.
+> `1.5.0.42`) rather than the `X.Y.Z.0` you see locally. The first three
+> segments are what you bump here; the fourth is just a CI counter.
+
 ### `wiki/Home.md`
 
 ```markdown


### PR DESCRIPTION
## Summary
  - Adds a note in `docs/RELEASING.md` under the version-bump section explaining
    that CI overrides the 4th AssemblyVersion segment with `BUILD_NUMBER`
    (auto-incremented via `build_bump.yml` using `VARIABLE_WRITE_TOKEN`).
  - Expands the header comment in `All/Version.cs` so the local-vs-shipped
    version discrepancy (`X.Y.Z.0` locally vs `X.Y.Z.<build#>` in CI artifacts)
    isn't surprising to future readers.

  ## Test plan
  - [ ] Skim `docs/RELEASING.md` rendered on GitHub — note appears as a blockquote under "Step 1 — Version bump →
  `All/Version.cs`".
  - [ ] Skim `All/Version.cs` — comment block above the assembly attributes reads cleanly.