### PR TITLE
v1.4.5: EC read-path hardening + threading/safety sweep + field reports

### DIFF
--- a/All/Version.cs
+++ b/All/Version.cs
@@ -12,7 +12,7 @@ using System.Reflection;
 // gets the full four segments including BUILD_NUMBER (auto-incremented by
 // .github/workflows/build_bump.yml), so shipped binaries appear as
 // X.Y.Z.<build#> in File Explorer / Get-FileHash properties.
-[assembly: AssemblyVersion("1.4.4.0")]
-[assembly: AssemblyFileVersion("1.4.4.0")]
-[assembly: AssemblyInformationalVersion("1.4.4-reborn")]
+[assembly: AssemblyVersion("1.4.5.0")]
+[assembly: AssemblyFileVersion("1.4.5.0")]
+[assembly: AssemblyInformationalVersion("1.4.5-reborn")]
 [assembly: AssemblyMetadata("Timestamp", "Undefined")]

--- a/App/Cli/CliOpDiag.cs
+++ b/App/Cli/CliOpDiag.cs
@@ -202,6 +202,19 @@ namespace OmenMon.AppCli {
             sb.AppendLine("## Live Fan Telemetry");
             sb.AppendLine();
             try {
+                // -Diag has not initialized the hardware interfaces yet at this point
+                // (ProbeEc, which opens Hw.Ec, runs later in DiagHardwareProbe). The fan
+                // readouts below go through FanArray/Fan, which read Hw.Bios and Hw.Ec, so
+                // open them here — otherwise this whole section devolves into a
+                // NullReferenceException row even on a perfectly healthy system. Both
+                // *Interface() helpers degrade gracefully (return null + App.Error) if the
+                // hardware genuinely can't be reached, in which case the calls below fall
+                // into the catch and report the real failure.
+                if(Hw.Bios == null || !Hw.Bios.IsInitialized)
+                    Hw.Bios = Hw.BiosInterface();
+                if(Hw.Ec == null || !Hw.Ec.IsInitialized)
+                    Hw.Ec = Hw.EcInterface();
+
                 var platform = new Platform();
                 var fans = platform.Fans;
 

--- a/App/Cli/CliOpDiag.cs
+++ b/App/Cli/CliOpDiag.cs
@@ -23,6 +23,8 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using OmenMon.Driver;
+using OmenMon.Hardware.Bios;
+using OmenMon.Hardware.Ec;
 using OmenMon.Hardware.Platform;
 using OmenMon.Library;
 
@@ -46,6 +48,7 @@ namespace OmenMon.AppCli {
             DiagEnvironment(sb);
             DiagDriverStatus(sb);
             DiagModelPreset(sb);
+            DiagFanState(sb);
             DiagAutoCalSidecar(sb);
             DiagEcTrace(sb);
             DiagCrashLogs(sb);
@@ -183,6 +186,68 @@ namespace OmenMon.AppCli {
 
         private static void AppendPresetRow(StringBuilder sb, string name, byte value) {
             sb.AppendLine($"| {name} | {value} | 0x{value:X2} |");
+        }
+#endregion
+
+#region Section: Live fan telemetry
+        // Live per-fan readout (issue #49 — "debug fans"). The single most common
+        // fan bug report is "RPM looks wrong / fan won't move", and triaging it
+        // previously meant cross-referencing the raw EC dump against the preset by
+        // hand. This section reads each fan's BIOS level, duty-cycle rate, the
+        // resolved live speed, AND the exact register/mode/multiplier Fan.GetSpeed()
+        // used to produce that speed — so a bogus RPM is immediately attributable to
+        // a wrong tachometer register or decode mode. Read-only: GetLevel/GetRate/
+        // GetSpeed never write to the EC.
+        private static void DiagFanState(StringBuilder sb) {
+            sb.AppendLine("## Live Fan Telemetry");
+            sb.AppendLine();
+            try {
+                var platform = new Platform();
+                var fans = platform.Fans;
+
+                sb.AppendLine($"- Mode: `{fans.GetMode()}`, Manual: `{fans.GetManual()}`, Max: `{fans.GetMax()}`, Off: `{fans.GetOff()}`, Countdown: `{fans.GetCountdown()}` s");
+                sb.AppendLine();
+                sb.AppendLine("| Fan | Level [krpm] | Rate [%] | Speed [rpm] | RPM source |");
+                sb.AppendLine("|-----|--------------|----------|-------------|------------|");
+
+                foreach(var fan in fans.Fan) {
+                    string type = fan.GetFanType().ToString();
+                    string level = TryFan(() => fan.GetLevel().ToString());
+                    string rate  = TryFan(() => fan.GetRate().ToString());
+                    string speed = TryFan(() => fan.GetSpeed().ToString());
+
+                    // Describe where the RPM came from, mirroring Fan.GetSpeed()'s
+                    // resolution order (AutoCal override → preset EC speed register).
+                    string source = "preset EC speed register";
+                    try {
+                        byte reg = 0;
+                        EcDiffScanner.Mode mode = default(EcDiffScanner.Mode);
+                        int mul = 0;
+                        bool have =
+                            fan.GetFanType() == BiosData.FanType.Cpu ? AutoCal.TryGetCpu(out reg, out mode, out mul) :
+                            fan.GetFanType() == BiosData.FanType.Gpu ? AutoCal.TryGetGpu(out reg, out mode, out mul) :
+                            false;
+                        if(have)
+                            source = mode == EcDiffScanner.Mode.BiosLevelMirror
+                                ? $"AutoCal BiosLevelMirror ×{(mul > 0 ? mul : 100)}"
+                                : $"AutoCal reg=0x{reg:X2}, mode={mode}, ×{mul}";
+                    } catch { }
+
+                    sb.AppendLine($"| {type} | {level} | {rate} | {speed} | {source} |");
+                }
+
+                string product = TryFan(() => new Settings().GetProduct());
+                if(AutoCal.IsKnownBoard(product))
+                    sb.AppendLine($"\n- `{product}` has a built-in RPM mapping (`AutoCal.KnownBoards`) — a blank EcDiffScanner result on this board is expected, not a fault.");
+
+            } catch(Exception ex) {
+                sb.AppendLine($"- Error reading fan telemetry: `{ex.GetType().Name}: {ex.Message}`");
+            }
+            sb.AppendLine();
+        }
+
+        private static string TryFan(Func<string> f) {
+            try { return f() ?? "?"; } catch(Exception ex) { return "err:" + ex.GetType().Name; }
         }
 #endregion
 

--- a/App/Gui/GuiTray.cs
+++ b/App/Gui/GuiTray.cs
@@ -603,10 +603,19 @@ namespace OmenMon.AppGui {
             // Update the notification icon and tray tooltip
             if(this.UpdateIconTick++ == 0) {
 
-                // Only force a fresh EC temperature read when the dynamic icon is active
-                // (same behavior as v1.1.x — avoids spurious hardware reads that can
-                // interfere with HP firmware power-management and cause forced hibernate)
-                if(this.Icon.IsDynamic) {
+                bool dynamicIcon = this.Icon.IsDynamic;
+
+                // C3: overtemperature protection must run on every icon tick whenever
+                // it is enabled (or needs clearing) — NOT only when the dynamic icon is
+                // active. Previously the forced temperature read, and with it the entire
+                // CheckThermalPanic call, lived inside the dynamic-icon branch, so simply
+                // turning the dynamic icon off silently disabled the thermal safety net.
+                // We still skip the read entirely when neither the icon nor panic
+                // protection needs it, preserving the spurious-read avoidance (v1.1.x)
+                // that keeps OmenMon from interfering with HP firmware power management.
+                bool panicActive = Config.ThermalPanicEnabled || this.Op.IsThermalPanic;
+
+                if(dynamicIcon || panicActive) {
 
                     bool needForcedUpdate =
                         (this.FormMain == null || !this.FormMain.Visible)
@@ -614,31 +623,31 @@ namespace OmenMon.AppGui {
 
                     byte maxTemp = this.Op.Platform.GetMaxTemperature(needForcedUpdate);
 
-                    // Thermal panic — only runs when we have a fresh, hardware-verified reading
+                    // Thermal panic — runs on a fresh, hardware-verified reading
+                    // regardless of icon mode. When ThermalPanicEnabled is false but a
+                    // panic is still latched (user disabled it at runtime), CheckThermalPanic
+                    // clears the stuck max-fan state itself.
                     this.Op.CheckThermalPanic(maxTemp);
 
-                    // Update the icon background based on fan mode
-                    this.Icon.SetBackground(
-                        this.Op.Platform.Fans.GetMode() == BiosData.FanMode.Performance ?
-                            GuiIcon.BackgroundType.Warm : GuiIcon.BackgroundType.Cool);
+                    if(dynamicIcon) {
 
-                    // Show temperature in configured unit.
-                    // The dynamic icon uses a custom bitmap font — only the localized °C glyph
-                    // is guaranteed to render. Omit the suffix when Fahrenheit is active rather
-                    // than passing a literal "°F" that may produce garbled characters.
-                    int displayTemp = Config.TemperatureUseFahrenheit
-                        ? (maxTemp * 9 / 5) + 32 : maxTemp;
-                    string unitSuffix = Config.TemperatureUseFahrenheit
-                        ? string.Empty
-                        : Config.Locale.Get(Config.L_UNIT + "Temperature" + Config.LS_CUSTOM_FONT);
-                    this.Icon.Update(Conv.GetString((uint) displayTemp, 2, 10) + unitSuffix);
+                        // Update the icon background based on fan mode
+                        this.Icon.SetBackground(
+                            this.Op.Platform.Fans.GetMode() == BiosData.FanMode.Performance ?
+                                GuiIcon.BackgroundType.Warm : GuiIcon.BackgroundType.Cool);
 
-                } else if(this.Op.IsThermalPanic) {
+                        // Show temperature in configured unit.
+                        // The dynamic icon uses a custom bitmap font — only the localized °C glyph
+                        // is guaranteed to render. Omit the suffix when Fahrenheit is active rather
+                        // than passing a literal "°F" that may produce garbled characters.
+                        int displayTemp = Config.TemperatureUseFahrenheit
+                            ? (maxTemp * 9 / 5) + 32 : maxTemp;
+                        string unitSuffix = Config.TemperatureUseFahrenheit
+                            ? string.Empty
+                            : Config.Locale.Get(Config.L_UNIT + "Temperature" + Config.LS_CUSTOM_FONT);
+                        this.Icon.Update(Conv.GetString((uint) displayTemp, 2, 10) + unitSuffix);
 
-                    // Dynamic icon was disabled while panic was active: silently restore fans.
-                    // ClearThermalPanic() skips the "Temperature normalized" balloon — the user
-                    // turned off the icon deliberately, not because the temperature dropped.
-                    this.Op.ClearThermalPanic();
+                    }
 
                 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **`EcWaitYieldCount` configuration knob** in `OmenMon.xml` (default 10), wired
   through `Config`/`ConfigData`, plus documentation of the EC-timing knobs and an
   RPM/temperature troubleshooting section (issue #14).
+- **HP OMEN 16 wd0xxx (8BA9, 2024) RPM read mapping** (`Library/AutoCal.cs`
+  `KnownBoards`, issue #92 reported by @M1918IIBAR). The Auto-Calibration scan found
+  a single 16-bit LE tachometer at `0xF1` and no GPU fan. The raw EC dumps confirm it:
+  `EC[0xF1..0xF2]` decodes to `0x0701` = 1793 RPM at 0% (idle) and `0x1405` = 5125 RPM
+  at 100% (max), matching the reported idle/max exactly and rising monotonically across
+  the 0/30/70/100% steps — LE16, not the `DirectMultiplier8` single-byte read 8BB3 uses
+  (which would decode the 100% step as 0x05 × 100 = 500 RPM). Added as a **read-only**
+  `KnownBoards` mapping flagged `SingleFan`, so RPM now displays correctly out of the box
+  and the GPU row mirrors the one real fan instead of decoding `0xF1` as a second word
+  (#81 pattern). No `<Model>` entry / fan-control registers are committed for this board —
+  a wrong `ManualReg`/`ModeReg` could lock the EC — so fan *control* stays on the
+  auto-detector's safe legacy fallback pending a confirmed register map.
 
 ### Deferred (need confirmed data before a code change is safe)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,108 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [1.4.5-reborn] - 2026-06-04
+
+> **EC read-path hardening + field-report sweep.** This release attacks the
+> root cause of the recurring "RPM = negative / millions" and bad-temperature
+> reports (#86) at the Embedded Controller read path itself, rather than per
+> board: a failed read now fails *cleanly* instead of returning a garbage byte,
+> 16-bit reads are validated against torn high/low bytes, the monitoring tick
+> batches its reads under a single mutex hold, and the #88 busy-wait backoff is
+> graduated so it can no longer pin the EC mutex past its timeout. Plus a
+> lifecycle-lock and a memory-model fix on the threading side, a null-guard for
+> non-Optimus systems, a thermal-panic safety fix, a more robust auto-detector,
+> live fan telemetry in `-Diag`, and a batch of model-database / calibration
+> updates.
+
+### Fixed
+
+- **Garbage bytes after the EC wait fail-limit (A1, issue #86).** `WaitRead()`
+  returned `true` unconditionally once `WaitReadFailCount` exceeded `EcFailLimit`
+  (15) — even though `OutFull` was never set — and the caller then read a
+  stale/garbage Data byte. Because the counter only reset on success, a briefly
+  wedged EC latched OmenMon permanently into the garbage path for minutes. This
+  is the most likely common root cause of the recurring "RPM = negative /
+  millions" and bad-temperature reports. A sustained wait-failure now returns
+  `false`, so the retry wrapper keeps the last good value instead of fabricating
+  one.
+- **Torn 16-bit reads (A2, issue #86).** `ReadWordImpl` reads the low and high
+  byte as two separate EC transactions, so an EC state change between them yields
+  a self-inconsistent word (implausible RPM). `ReadWord` now requires two
+  consecutive identical reads before trusting the value, falling back to the most
+  recent successful read.
+- **Per-sensor EC lock churn on the monitoring path (A3, issue #86).** Each
+  `EcComponent.Update()` opened the driver and took/released the cross-process
+  `Global\Access_EC` mutex on its own, so a monitor tick churned the lock once per
+  sensor and widened the collision window with the kernel ACPI EC driver. New
+  `Hw.EcExecBatch()` holds the EC open and the (reentrant) mutex for the whole
+  tick; `Platform.UpdateTemperature()` reads the full sensor array inside one
+  batch.
+- **EC wait backoff could exceed the mutex timeout (A4, issue #88).** The #88
+  backoff slept a full 1 ms per iteration while holding `Global\Access_EC`, so a
+  Word read could pin the mutex past `EcMutexTimeout` (200 ms) and starve other
+  waiters into `ErrEcLock`. `Wait()` now yields the timeslice (`Sleep(0)`) for a
+  configurable `EcWaitYieldCount` (default 10) iterations before escalating to the
+  1 ms sleep, cutting the worst-case per-`Wait` hold from 25 ms to 15 ms.
+- **EC lifecycle race (B1).** `Initialize()`/`Close()` checked and set
+  `IsInitialized` without synchronisation while reads ran from the GUI tick,
+  AutoConfig thread, key handler and heartbeat — a use-after-close window. Both
+  now run under a per-singleton lifecycle lock.
+- **`gpuTempObserved` data race (B2).** The sticky observed-GPU-temperature flag
+  is now `volatile` so its first-non-zero transition publishes deterministically.
+- **`NullReferenceException` in `NvMuxGetState()` on non-Optimus systems (C1).**
+  The mux registry key only exists on NV-Optimus laptops; the method now returns
+  `NvMuxState?` and yields `null` when the key/value is absent instead of
+  dereferencing it.
+- **Thermal-panic protection was tied to the dynamic tray icon (C3).** The
+  forced temperature read and `CheckThermalPanic()` lived inside the
+  `if(Icon.IsDynamic)` branch, so turning the dynamic icon off silently disabled
+  over-temperature protection. Thermal panic now runs on every icon tick whenever
+  enabled (or a latched panic needs clearing), independent of icon mode, while
+  still skipping the EC read when neither the icon nor panic needs it.
+- **8A18 (OMEN 17 ck1000nw) post-calibration fan lock (issue #84).** The
+  confirmed `0xB0`/`0xB2` tachometers are now pinned in `AutoCal.KnownBoards` too,
+  so `Load()`'s collision self-heal always has a verified built-in mapping to fall
+  back to and a stale/foreign sidecar can no longer relock the fans.
+- **GPU fan row showed garbage on single-fan boards (issue #81, 8BB3).** A
+  `Mapping.SingleFan` flag now makes `Prime()` mirror the resolved CPU mapping onto
+  the GPU when the board is single-fan and the GPU has no override, so both rows
+  report the one real fan instead of decoding `0xF1` as a word.
+
+### Added
+
+- **More robust EC layout auto-detection (issue #37).** The 2022 match no longer
+  *requires* a live tachometer (idle fans / off-`0xB0` tachs made it misfire to the
+  2023 layout); a plausible fan level at the layout's setpoint register is required
+  instead, and a fan-level fallback tier now handles boards whose `CPUT` is neither
+  a valid temperature nor the `0xFF` sentinel. Read-only and conservative.
+- **Live Fan Telemetry section in `-Diag` (issue #49).** Per-fan BIOS level,
+  duty-cycle rate, resolved live speed, and the exact register/mode/multiplier
+  `Fan.GetSpeed()` used — so a wrong RPM is immediately traceable to the register.
+- **Native HP Omen Max 16 (8D41, 2025) entry (issues #87, #90).** Graduated from
+  the read-only `AutoCal` RPM mapping to a full `<Model>` entry with the confirmed
+  16-bit LE tachometers at `0x5C` (CPU) / `0x9F` (GPU). Fan-control registers are
+  the legacy defaults the unknown-model fallback already applied (non-regressive
+  for control) and remain flagged unverified pending an owner `-Diag`.
+- **Omen 16-am1001nw coverage (issue #31).** Documented as covered by the existing
+  `8E71` (Omen 16-am1xxx) entry; `@Bart82`'s board is the same `#88` EC-timeout
+  reporter and benefits from the A4 backoff fix.
+- **`EcWaitYieldCount` configuration knob** in `OmenMon.xml` (default 10), wired
+  through `Config`/`ConfigData`, plus documentation of the EC-timing knobs and an
+  RPM/temperature troubleshooting section (issue #14).
+
+### Deferred (need confirmed data before a code change is safe)
+
+- **HP Omen 16-wd0004nw (#51 model / #75 calibration), xd0020ax (#77), and the
+  AMD Ryzen 9 7945HS SKU (#85).** No confirmed Product ID + register dump is
+  available, and HP recycles Product IDs across regional/CPU variants — a prior
+  7945HS-class report (#76/#85 on `8BCA`) already gave conflicting tachometer
+  layouts. Shipping a guessed register map risks garbage RPM or a fan-controller
+  lock on other owners' machines. All are usable today via the read-only
+  auto-detector + the Auto-Calibration wizard; documented under "Pending field
+  reports" in `wiki/Model-Database.md` with exactly the `-Diag`/calibration data
+  needed to promote each to the shipped database.
+
 ## [1.4.4-reborn] - 2026-06-02
 
 > **Post-v1.4.3 field-report sweep.** A patch closing the non-pending issues that arrived after v1.4.3: a new board for the native model database, a tray-menu fan-control gap that left fans pinned at maximum after switching to an automatic mode, a calibration self-heal for a CPU fan reading that mirrored the GPU after a single-fan scan, a misleading Auto-Calibration report on boards whose RPM is already handled by a built-in mapping, an EC busy-wait backoff that stops OmenMon hammering the controller while the OS/BIOS holds it (a suspected cause of ACPI-timeout shutdowns), and a read-only RPM mapping for the 2025 Omen Max 16. No hardware-control behaviour changes beyond releasing Max Fan when the user picks a fan mode.

--- a/Hardware/AutoDetector.cs
+++ b/Hardware/AutoDetector.cs
@@ -28,24 +28,56 @@ namespace OmenMon.Hardware.Platform {
                 byte rpm1Lo = ec[(byte) EmbeddedControllerData.Register.RPM1]; // 0xB0
                 byte rpm1Hi = ec[(byte) EmbeddedControllerData.Register.RPM2]; // 0xB1
                 int  rpm1   = (rpm1Hi << 8) | rpm1Lo;
-                bool rpm1Valid = rpm1 >= 0 && rpm1 <= 7000;
+
+                // Fan-level plausibility at each layout's setpoint register. A real fan
+                // level is small (krpm setpoint, 0–55); 0xFF means "BIOS auto / not this
+                // layout" and anything larger than ~55 is not a level.
+                byte fanLevel2022 = ec[PlatformPreset.Default.FanLevelReg0];     // 0x34
+                byte fanLevel2023 = ec[PlatformPreset.Default2023.FanLevelReg0]; // 0x11
+                bool level2022Plausible = fanLevel2022 <= 55;
+                bool level2023Plausible = fanLevel2023 <= 55;
+
+                // #37: a plausible, non-zero 16-bit LE tachometer at 0xB0 is a strong
+                // positive signal but must not be *required* — fans can be idle (0 RPM)
+                // at detection time, and some boards site the tach elsewhere. Treat 0 and
+                // the 0xFFFF "register absent" sentinel as "no signal" rather than valid.
+                bool rpm1Strong = rpm1 > 0 && rpm1 <= 7000;
 
                 // Layout A — standard 2022 (Omen 16 b1xxx/k0xxx): FanLevel at 0x34/0x35.
                 // Signal: CPUT at 0x57 returns a plausible CPU temperature (20–95 °C).
-                if(cput >= 20 && cput <= 95 && rpm1Valid)
+                // #37: the mandatory rpm1Valid requirement is dropped — CPUT in 20–95
+                // already excludes the 2023+ 0xFF case, and demanding a live RPM made the
+                // detector misfire to the 2023 layout on 2022 boards whose tach sits off
+                // 0xB0 or whose fans were idle. A plausible 2022 fan level is required
+                // instead so we don't claim the layout on a board that clearly isn't it.
+                if(cput >= 20 && cput <= 95 && level2022Plausible)
                     return FromTemplate(productId, PlatformPreset.Default, "2022 layout");
 
                 // Layout B — 2023+ (Victus/Omen 16 2023+): FanLevel at 0x11/0x12.
                 // Signal: CPUT at 0x57 = 0xFF (overlaps firmware string data on these models)
                 // AND EC[FanLevelReg0] holds a plausible fan level (0–55).
                 // RPM is NOT checked here: some 2023+ models (e.g. 8BAB) have RPM registers
-                // at a different address than 0xB0/0xB1, so rpm1Valid would be false even
+                // at a different address than 0xB0/0xB1, so rpm1Strong would be false even
                 // when the layout is correct. cput==0xFF + fanLevel range is discriminating enough.
-                if(cput == 0xFF || cput == 0x0F) {
-                    byte fanLevel = ec[PlatformPreset.Default2023.FanLevelReg0];
-                    if(fanLevel <= 55)
-                        return FromTemplate(productId, PlatformPreset.Default2023, "2023+ layout");
+                if((cput == 0xFF || cput == 0x0F) && level2023Plausible)
+                    return FromTemplate(productId, PlatformPreset.Default2023, "2023+ layout");
+
+                // Layout C — CPUT ambiguous (neither a plausible temperature nor the 0xFF
+                // sentinel, e.g. a board that parks 0x57 at an odd constant). #37: rather
+                // than give up and force the global default, disambiguate purely on which
+                // setpoint register holds a plausible fan level. The 2022 and 2023 level
+                // registers (0x34 vs 0x11) are far apart, so it is rare for both to look
+                // plausible at once; require an *exclusive* match to stay conservative, and
+                // prefer the layout that also shows a live tach at 0xB0 when both qualify.
+                if(level2022Plausible != level2023Plausible) {
+                    if(level2022Plausible)
+                        return FromTemplate(productId, PlatformPreset.Default, "2022 layout (fan-level inferred)");
+                    return FromTemplate(productId, PlatformPreset.Default2023, "2023+ layout (fan-level inferred)");
                 }
+                if(level2022Plausible && level2023Plausible && rpm1Strong)
+                    // Both ambiguous but a real RPM is present: the legacy 0xB0 tach is the
+                    // 2022/early-Victus signature, so lean 2022.
+                    return FromTemplate(productId, PlatformPreset.Default, "2022 layout (tach inferred)");
 
             } catch { }
 

--- a/Hardware/Ec.cs
+++ b/Hardware/Ec.cs
@@ -84,12 +84,30 @@ namespace OmenMon.Hardware.Ec {
         public virtual ushort ReadWord(byte register) {
             int count = 0;
             ushort value = 0;
+            ushort previous = 0;
+            bool havePrevious = false;
             while(count < Config.EcRetryLimit) {
-                if(ReadWordImpl(register, out value))
-                    return (ushort) value;
+                if(ReadWordImpl(register, out value)) {
+
+                    // A2 (issue #86): ReadWordImpl reads the low and high byte as two
+                    // separate EC transactions, each with its own wait logic, so an EC
+                    // state change between the bytes (or a single-byte wait failure)
+                    // produces a self-inconsistent 16-bit value — directly visible as
+                    // implausible RPM spikes. Validate by requiring two consecutive
+                    // identical word reads before trusting the result: a genuine reading
+                    // is stable across a few microseconds, a torn one is not.
+                    if(havePrevious && value == previous)
+                        return value;
+                    previous = value;
+                    havePrevious = true;
+
+                }
                 count++;
             }
-            return (ushort) value;
+
+            // Could not obtain two agreeing reads within the retry budget: return the
+            // most recent successful read rather than a value known to be torn.
+            return value;
         }
 
         // Wrapper to write a byte to an Embedded Controller register
@@ -196,23 +214,46 @@ namespace OmenMon.Hardware.Ec {
                 // case — EC ready within a spin or two — never sleeps, so GUI refresh
                 // latency is unchanged; only a contended EC yields the CPU. Set
                 // EcWaitSpinCount >= EcWaitLimit to restore the legacy pure-spin.
+                //
+                // A4 (issue #88): the original #88 fix slept a full 1 ms for every
+                // backoff iteration. Because Wait() runs while Global\Access_EC is held,
+                // a Word read (up to ~8 Waits) could pin the mutex for far longer than
+                // EcMutexTimeout (200 ms), starving the heartbeat / GUI / AutoConfig
+                // waiters into ErrEcLock. Now the backoff is graduated: yield the
+                // timeslice (Thread.Sleep(0), no fixed delay) for EcWaitYieldCount
+                // iterations first so a momentarily-busy EC recovers without burning a
+                // millisecond per poll, and only escalate to the 1 ms sleep once even
+                // yielding hasn't cleared it. With the defaults (spin 5, yield 10, limit
+                // 30) the worst-case hold per Wait drops from 25 ms to 15 ms while still
+                // relieving the busy-spin that provoked the ACPI timeout shutdowns.
                 if(i >= Config.EcWaitSpinCount)
-                    Thread.Sleep(1);
+                    Thread.Sleep(i < Config.EcWaitSpinCount + Config.EcWaitYieldCount ? 0 : 1);
             }
             return false;
         }
 
         // Waits for a read operation
         protected bool WaitRead() {
-            if(WaitReadFailCount > Config.EcFailLimit) {
-                return true;
-            } else if(Wait(Status.OutFull, true)) {
+            if(Wait(Status.OutFull, true)) {
                 WaitReadFailCount = 0;
                 return true;
-            } else {
-                WaitReadFailCount++;
-                return false;
             }
+
+            // A1 (issue #86): the legacy implementation returned **true** once
+            // WaitReadFailCount exceeded EcFailLimit (15) even though OutFull was
+            // never set — the caller then read the Data port and got a stale/garbage
+            // byte. Worse, WaitReadFailCount was only ever reset on success, so the
+            // moment the EC was briefly wedged OmenMon latched permanently into the
+            // "always-true" mode and reported garbage for minutes. That self-
+            // perpetuating fail-limit hack is the most likely root cause of the
+            // recurring "RPM = negative / millions" and bad-temperature reports.
+            // A sustained wait failure now returns **false**: ReadByteImpl propagates
+            // the failure to the retry wrapper (ReadByte/ReadWord), which keeps the
+            // last good value instead of fabricating one. The counter is retained as
+            // a diagnostic signal (surfaced via EcTrace / -Diag) but no longer gates
+            // behaviour.
+            WaitReadFailCount++;
+            return false;
         }
 
         // Waits for a write operation
@@ -237,31 +278,45 @@ namespace OmenMon.Hardware.Ec {
             get { return instance; }
         }
 
+        // Serialises Initialize()/Close() on the singleton. The IsInitialized
+        // check-then-set in both methods was previously unsynchronised even though
+        // reads originate from the GUI tick, the AutoConfig background thread, the
+        // Omen-key handler and the heartbeat tick — so an EcInterface() init could
+        // race a parallel Close() and dispose the Ring0 driver out from under an
+        // in-flight read (use-after-close). The cross-process EC mutex only serialises
+        // port I/O during EcExec, not lifecycle, so this in-process lock closes the gap
+        // (B1).
+        private readonly object lifecycleLock = new object();
+
         // Initializes the kernel driver and creates a lock on the Embedded Controller
         public override void Initialize() {
-            if(!this.IsInitialized) {
-                Ring0.Open();
-                if(Ring0.IsOpen) {
-                    this.IsInitialized = true;
-                    EmbeddedControllerMutex.Open();
-                } else {
-                    // Report driver installation failure details
-                    App.Error(Ring0.GetStatus());
+            lock(this.lifecycleLock) {
+                if(!this.IsInitialized) {
+                    Ring0.Open();
+                    if(Ring0.IsOpen) {
+                        this.IsInitialized = true;
+                        EmbeddedControllerMutex.Open();
+                    } else {
+                        // Report driver installation failure details
+                        App.Error(Ring0.GetStatus());
+                    }
                 }
             }
         }
 
         // Closes the kernel driver and clears the Embedded Controller lock
         public override void Close() {
-            if(this.IsInitialized) {
-                this.IsInitialized = false;
-                try {
-                    EmbeddedControllerMutex.Close();
-                } catch {
-                }
-                try {
-                    Ring0.Close();
-                } catch {
+            lock(this.lifecycleLock) {
+                if(this.IsInitialized) {
+                    this.IsInitialized = false;
+                    try {
+                        EmbeddedControllerMutex.Close();
+                    } catch {
+                    }
+                    try {
+                        Ring0.Close();
+                    } catch {
+                    }
                 }
             }
         }

--- a/Hardware/Platform.cs
+++ b/Hardware/Platform.cs
@@ -29,7 +29,13 @@ namespace OmenMon.Hardware.Platform {
         // CPU temp) from "this board has no real GPU temp sensor at all and GPTM
         // is just the default global config entry reading 0 forever" (fall back).
         // See Copilot review #1 on PR #62 / issue #66.
-        private bool gpuTempObserved = false;
+        //
+        // Marked volatile (B2): the flag is written from GetGpuTemperature() (GUI tick /
+        // fan-program tick) and read from HasObservedGpuTemperature() (FanProgram on a
+        // background path), so an unsynchronised plain bool could in principle have its
+        // first-non-zero transition seen late on a weak memory model. volatile gives the
+        // sticky latch a defined publish/acquire without the cost of a lock.
+        private volatile bool gpuTempObserved = false;
 
         // System information
         public ISettings System { get; private set; }
@@ -344,9 +350,21 @@ namespace OmenMon.Hardware.Platform {
 
         // Updates the temperature readings
         public void UpdateTemperature(bool onlyUsed = false) {
-            for(int i = 0; i < Temperature.Length; i++)
-                if(!onlyUsed || this.TemperatureUse[i])
-                    this.Temperature[i].Update();
+
+            // A3 (issue #86): batch every sensor read for this tick under one EC
+            // open + mutex hold instead of letting each EcComponent.Update() take and
+            // release Global\Access_EC on its own. This collapses N lock cycles per
+            // monitor tick to a single hold, shrinking the contention window with the
+            // kernel ACPI EC driver (the same contention #88's backoff addresses). The
+            // mutex is reentrant on the owning thread, so the inner per-register reads
+            // are uncontended re-entries; WMI-backed sensors inside the block simply
+            // do not touch the EC. EcExecBatch skips the body if the EC cannot be
+            // opened, the same degradation a per-sensor EcExec would have produced.
+            Hw.EcExecBatch(() => {
+                for(int i = 0; i < Temperature.Length; i++)
+                    if(!onlyUsed || this.TemperatureUse[i])
+                        this.Temperature[i].Update();
+            });
         }
 #endregion
 

--- a/Hardware/Platform.cs
+++ b/Hardware/Platform.cs
@@ -358,13 +358,19 @@ namespace OmenMon.Hardware.Platform {
             // kernel ACPI EC driver (the same contention #88's backoff addresses). The
             // mutex is reentrant on the owning thread, so the inner per-register reads
             // are uncontended re-entries; WMI-backed sensors inside the block simply
-            // do not touch the EC. EcExecBatch skips the body if the EC cannot be
-            // opened, the same degradation a per-sensor EcExec would have produced.
-            Hw.EcExecBatch(() => {
+            // do not touch the EC.
+            Action updateAll = () => {
                 for(int i = 0; i < Temperature.Length; i++)
                     if(!onlyUsed || this.TemperatureUse[i])
                         this.Temperature[i].Update();
-            });
+            };
+
+            // If the EC can't be opened/locked this tick, still update directly so the
+            // WMI BIOS temperature sensor (which never touches the EC) keeps refreshing;
+            // the EC-backed sensors then degrade per-component exactly as they did before
+            // the batch existed, rather than the whole tick being skipped.
+            if(!Hw.EcExecBatch(updateAll))
+                updateAll();
         }
 #endregion
 

--- a/INSTRUCTION.md
+++ b/INSTRUCTION.md
@@ -243,9 +243,26 @@ Located in the same folder as `OmenMon.exe`. Key settings:
 
     <!-- GPU power default -->
     <GpuPowerDefault>Maximum</GpuPowerDefault>
+
+    <!-- Embedded Controller timing (advanced — defaults are fine for almost everyone) -->
+    <EcWaitSpinCount>5</EcWaitSpinCount>
+    <EcWaitYieldCount>10</EcWaitYieldCount>
   </Config>
 </OmenMon>
 ```
+
+### EcWaitSpinCount / EcWaitYieldCount
+
+**Advanced EC-timing knobs.** When OmenMon waits for the Embedded Controller it
+first spins (`EcWaitSpinCount` iterations, default **5**), then yields the CPU
+timeslice for `EcWaitYieldCount` iterations (default **10**), and only then
+sleeps 1 ms per poll. The yield stage was added in **v1.4.5** (issue #88, the
+"A4" follow-up): because the wait runs while OmenMon holds the cross-process EC
+mutex, an all-1 ms backoff could pin the mutex past the 200 ms `EcMutexTimeout`
+and make other waiters (heartbeat, GUI tick, calibration) report `ErrEcLock`.
+Yielding first bounds the worst-case hold. Leave these at the defaults unless
+you are diagnosing EC contention; set `EcWaitSpinCount` ≥ `EcWaitLimit` to
+restore the legacy pure busy-spin.
 
 ### BiosHeartbeatPauseOnBattery
 
@@ -286,6 +303,34 @@ Your device's EC register layout may differ from the default. Run **Auto-Calibra
 ### CPU temperature not shown or wrong zone count (RGB)
 
 Known on some OMEN Max 16 / non-standard models. Use `Probe` mode to identify your EC layout. See [wiki/Contributing-Hardware-Data.md](wiki/Contributing-Hardware-Data.md).
+
+### Fan RPM or temperature reads as negative, "millions", or obviously wrong
+
+Two independent causes, both improved in **v1.4.5**:
+
+1. **Transient garbage from a busy EC.** Earlier builds, after enough failed
+   read-waits, returned the Data port unconditionally — a stale/garbage byte —
+   and once that happened the controller stayed stuck in the garbage path for
+   minutes (the recurring "RPM = negative / millions" reports, issue #86).
+   v1.4.5 makes a sustained wait-failure fail cleanly so the last good value is
+   kept instead, and validates 16-bit reads against torn high/low bytes. No
+   action needed — just update.
+2. **Wrong tachometer register for your board.** If the *steady-state* RPM is
+   wrong (not just an occasional spike), your model's EC layout differs from the
+   preset. Run **Auto-Calibrate & Diagnose…** from the tray menu, or run
+   `OmenMon.exe -Diag` and check the new **Live Fan Telemetry** section (issue
+   #49): it shows each fan's level, rate, resolved speed, and the exact
+   register/mode/multiplier used — so a bad RPM is immediately traceable to the
+   register. Paste the `-Diag` output into a GitHub issue and the board can be
+   added to the native database.
+
+### Over-temperature (Thermal Panic) protection and the tray icon
+
+As of **v1.4.5** the over-temperature safety net (both fans forced to maximum
+above the configured threshold) runs on every monitor tick whenever
+`ThermalPanicEnabled` is set — **independently of whether the dynamic
+temperature tray icon is enabled**. Previously, turning the dynamic icon off
+silently disabled thermal-panic protection (issue addressed as bug "C3").
 
 ### BSOD / Memory integrity conflicts
 

--- a/Library/AutoCal.cs
+++ b/Library/AutoCal.cs
@@ -333,6 +333,9 @@ namespace OmenMon.Library {
         private struct Mapping {
             public byte CpuReg; public EcDiffScanner.Mode CpuMode; public int CpuMul;
             public byte GpuReg; public EcDiffScanner.Mode GpuMode; public int GpuMul;
+            // Single physical fan: the GPU fan row should mirror the CPU reading rather
+            // than fall back to the (wrongly-decoded) preset FanSpeedReg1 (#81).
+            public bool SingleFan;
         }
 
         private static readonly Dictionary<string, Mapping> KnownBoards =
@@ -394,6 +397,7 @@ namespace OmenMon.Library {
             ["8BB3"] = new Mapping {
                 CpuReg = 0xF1, CpuMode = EcDiffScanner.Mode.DirectMultiplier8, CpuMul = 0,
                 GpuReg = 0, GpuMode = default(EcDiffScanner.Mode), GpuMul = 0,
+                SingleFan = true,
             },
 
             // HP Omen Max 16 (8D41, 2025) — issue #87, reported by @Keith1341.
@@ -411,6 +415,21 @@ namespace OmenMon.Library {
                 GpuReg = 0x9F, GpuMode = EcDiffScanner.Mode.LittleEndian16, GpuMul = 0,
             },
 
+            // HP OMEN 17 ck1000nw (8A18, 2022) — issue #84, reported by @xenon205.
+            // The native <Model> entry already pins FanSpeedReg0/1 = 0xB0/0xB2, but a
+            // stale or foreign AutoCal sidecar (or a single-fan rescan) could override
+            // that with a wrong register and reintroduce the post-calibration "garbage
+            // RPM → fan lock / hibernation" symptom the user reported. Pinning the
+            // confirmed 16-bit LE tachometers here too means Load()'s collision
+            // self-heal always has a verified built-in mapping to fall back to, and a
+            // wizard-free install reads correct RPM out of the box. Decoded from the
+            // user's report (0/30/70/100% sweep): CPU 0/1476/3218/3422, GPU
+            // 0/1448/3115/3363 — matching the native preset exactly.
+            ["8A18"] = new Mapping {
+                CpuReg = 0xB0, CpuMode = EcDiffScanner.Mode.LittleEndian16, CpuMul = 0,
+                GpuReg = 0xB2, GpuMode = EcDiffScanner.Mode.LittleEndian16, GpuMul = 0,
+            },
+
         };
 
         // Pre-populates AutoCal overrides for a known board, *per fan*. Called from
@@ -426,6 +445,17 @@ namespace OmenMon.Library {
             if(!KnownBoards.TryGetValue(productId, out var m)) return;
             if(!HasCpu && (m.CpuReg != 0 || m.CpuMode == EcDiffScanner.Mode.BiosLevelMirror)) SetCpu(m.CpuReg, m.CpuMode, m.CpuMul);
             if(!HasGpu && (m.GpuReg != 0 || m.GpuMode == EcDiffScanner.Mode.BiosLevelMirror)) SetGpu(m.GpuReg, m.GpuMode, m.GpuMul);
+
+            // #81 (reported by @jpcaldwell30 on 8BB3): single-fan SKUs expose one physical
+            // fan, but the GUI/preset still carries a GPU fan whose FanSpeedReg1 points at
+            // the same register decoded the wrong way (a DirectMultiplier8 byte read as an
+            // LE16 word), so the GPU row showed garbage. When the board is flagged single-fan
+            // and the GPU side has no override of its own, mirror the resolved CPU mapping
+            // onto the GPU so both rows report the one real fan's RPM. CollidesWithNativePreset()
+            // exempts single-fan presets (FanSpeedReg0 == FanSpeedReg1), so this mirror is not
+            // mistaken for a #83 mis-detection.
+            if(m.SingleFan && !HasGpu && TryGetCpu(out byte cReg, out var cMode, out int cMul))
+                SetGpu(cReg, cMode, cMul);
         }
 
         // Reports whether a board has a built-in RPM mapping in KnownBoards.

--- a/Library/AutoCal.cs
+++ b/Library/AutoCal.cs
@@ -400,6 +400,26 @@ namespace OmenMon.Library {
                 SingleFan = true,
             },
 
+            // HP OMEN 16 wd0xxx (8BA9, 2024) — issue #92, reported by @M1918IIBAR.
+            // Single-fan SKU. The Auto-Calibration scan detected one 16-bit LE
+            // tachometer at 0xF1 and no GPU fan (physically single-fan chassis or a
+            // second fan on a different bus). Decoded from the report's 0/30/70/100%
+            // sweep, EC[0xF1..0xF2]: 0% = 01 07 → 0x0701 = 1793 RPM (idle), 100% =
+            // 05 14 → 0x1405 = 5125 RPM (max), matching the reported idle/max exactly
+            // and rising monotonically across the steps — so LE16 at 0xF1, not the
+            // DirectMultiplier8 single-byte read 8BB3 uses (which would decode 100% as
+            // 0x05 × 100 = 500 RPM, far below the audible max). Read-only mapping only:
+            // no fan-control registers are committed for this board (a wrong
+            // ManualReg/ModeReg could lock the EC), so RPM displays correctly while
+            // fan *control* stays on the auto-detector's safe legacy fallback. SingleFan
+            // mirrors the resolved CPU mapping onto the GPU row so it stops decoding
+            // 0xF1 as a second word (#81 pattern).
+            ["8BA9"] = new Mapping {
+                CpuReg = 0xF1, CpuMode = EcDiffScanner.Mode.LittleEndian16, CpuMul = 0,
+                GpuReg = 0, GpuMode = default(EcDiffScanner.Mode), GpuMul = 0,
+                SingleFan = true,
+            },
+
             // HP Omen Max 16 (8D41, 2025) — issue #87, reported by @Keith1341.
             // The wizard's live-RPM column read blank because Fan.GetSpeed() fell back
             // to the default 0xB0/0xB2 preset (wrong for this 2025 "Omen Max" layout),

--- a/Library/Config.cs
+++ b/Library/Config.cs
@@ -259,6 +259,9 @@ namespace OmenMon.Library {
                     if(GetWord(xml, XmlPrefix + "EcWaitSpinCount", out value))
                         EcWaitSpinCount = value;
 
+                    if(GetWord(xml, XmlPrefix + "EcWaitYieldCount", out value))
+                        EcWaitYieldCount = value;
+
                     if(GetBool(xml, XmlPrefix + "FanCountdownExtendAlways", out flag))
                         FanCountdownExtendAlways = flag;
 
@@ -692,6 +695,7 @@ namespace OmenMon.Library {
                     SetUInt(xml, XmlPrefix + "EcRetryLimit", (uint) EcRetryLimit);
                     SetUInt(xml, XmlPrefix + "EcWaitLimit", (uint) EcWaitLimit);
                     SetUInt(xml, XmlPrefix + "EcWaitSpinCount", (uint) EcWaitSpinCount);
+                    SetUInt(xml, XmlPrefix + "EcWaitYieldCount", (uint) EcWaitYieldCount);
                     SetBool(xml, XmlPrefix + "FanCountdownExtendAlways", FanCountdownExtendAlways);
                     SetUInt(xml, XmlPrefix + "FanCountdownExtendInterval", (uint) FanCountdownExtendInterval);
                     SetUInt(xml, XmlPrefix + "FanCountdownExtendThreshold", (uint) FanCountdownExtendThreshold);

--- a/Library/ConfigData.cs
+++ b/Library/ConfigData.cs
@@ -127,7 +127,8 @@ namespace OmenMon.Library {
         public static int EcFailLimit  = 15;  // Maximum number of failed attempts waiting to read
         public static int EcRetryLimit =  3;  // Maximum number of read and write attempts
         public static int EcWaitLimit  = 30;  // Iterations before waiting fails each time
-        public static int EcWaitSpinCount = 5; // Fast spins before backing off to a 1 ms sleep while waiting on a busy EC (issue #88; >= EcWaitLimit restores the legacy pure-spin)
+        public static int EcWaitSpinCount = 5; // Fast spins before backing off while waiting on a busy EC (issue #88; >= EcWaitLimit restores the legacy pure-spin)
+        public static int EcWaitYieldCount = 10; // Iterations after EcWaitSpinCount that yield (Thread.Sleep(0)) before escalating to a 1 ms sleep, bounding the worst-case mutex hold below EcMutexTimeout (A4, issue #88)
 
         // Environment variable settings
         public static string EnvVarSelfName = AppName;

--- a/Library/Hw.cs
+++ b/Library/Hw.cs
@@ -244,20 +244,40 @@ namespace OmenMon.Library {
         }
 
         // Runs a batch of EC reads/writes under a single EC open + mutex hold (A3, issue #86).
-        // The regular monitoring path previously had every EcComponent.Update() open the
-        // driver and take/release the cross-process Global\Access_EC mutex on its own, so a
-        // single monitor tick churned the lock once per sensor — multiplying the collision
-        // window with the kernel ACPI EC driver that #88's backoff fights. Wrapping a tick's
-        // reads in this method holds the lock for the whole batch; the named mutex is
-        // reentrant on the owning thread, so the inner per-register EcGetByte/EcGetWord calls
-        // (which acquire via the (callback, Hw.Ec) overload) become uncontended re-entries
-        // rather than fresh cross-process acquisitions. If the EC cannot be opened the body
-        // is skipped for this tick, exactly as an individual EcExec would have failed.
-        public static void EcExecBatch(Action body) {
-            using(Ec = EcInterface()) {
-                if(Ec != null)
-                    EcExec(_ => body(), Ec);
+        // The regular monitoring path previously had every EcComponent.Update() take and
+        // release the cross-process Global\Access_EC mutex on its own, so a single monitor
+        // tick churned the lock once per sensor — multiplying the collision window with the
+        // kernel ACPI EC driver that #88's backoff fights. Wrapping a tick's reads in this
+        // method holds the lock for the whole batch; the named mutex is reentrant on the
+        // owning thread, so the inner per-register EcGetByte/EcGetWord calls (which acquire
+        // via the (callback, Hw.Ec) overload) become uncontended re-entries rather than
+        // fresh cross-process acquisitions.
+        //
+        // Reuse the persistently-initialized singleton (opened once via EcInit()) rather than
+        // opening it in a using() scope: Hw.Ec is the same instance the non-batched read path
+        // (EcGetByte/EcGetWord) operates on directly, so disposing it here would Close() Ring0
+        // + the Global\Access_EC mutex out from under the very next read outside the batch.
+        //
+        // Returns true if the body ran under the EC lock; false if the EC was unavailable or
+        // the lock could not be acquired this tick, so the caller can fall back to updating
+        // any non-EC (e.g. WMI-backed) sensors directly.
+        public static bool EcExecBatch(Action body) {
+            if(body == null)
+                return false;
+            if(Ec == null || !Ec.IsInitialized)
+                Ec = EcInterface();
+            if(Ec == null || !Ec.IsInitialized)
+                return false;
+            if(Ec.Request(Config.EcMutexTimeout)) {
+                try {
+                    body();
+                } finally {
+                    Ec.Release();
+                }
+                return true;
             }
+            App.Error("ErrEcLock");
+            return false;
         }
 
         // Prepares the Embedded Controller, runs operations while it is locked for exclusive use, and returns a result

--- a/Library/Hw.cs
+++ b/Library/Hw.cs
@@ -243,6 +243,23 @@ namespace OmenMon.Library {
             }
         }
 
+        // Runs a batch of EC reads/writes under a single EC open + mutex hold (A3, issue #86).
+        // The regular monitoring path previously had every EcComponent.Update() open the
+        // driver and take/release the cross-process Global\Access_EC mutex on its own, so a
+        // single monitor tick churned the lock once per sensor — multiplying the collision
+        // window with the kernel ACPI EC driver that #88's backoff fights. Wrapping a tick's
+        // reads in this method holds the lock for the whole batch; the named mutex is
+        // reentrant on the owning thread, so the inner per-register EcGetByte/EcGetWord calls
+        // (which acquire via the (callback, Hw.Ec) overload) become uncontended re-entries
+        // rather than fresh cross-process acquisitions. If the EC cannot be opened the body
+        // is skipped for this tick, exactly as an individual EcExec would have failed.
+        public static void EcExecBatch(Action body) {
+            using(Ec = EcInterface()) {
+                if(Ec != null)
+                    EcExec(_ => body(), Ec);
+            }
+        }
+
         // Prepares the Embedded Controller, runs operations while it is locked for exclusive use, and returns a result
         public static TResult EcExec<TResult>(Func<IEmbeddedController,TResult> callback) {
             using(Ec = EcInterface()) {
@@ -318,10 +335,19 @@ namespace OmenMon.Library {
             Discrete = 0x00000002   // Discrete GPU only
         }
 
-        // Retrieves the current nVidia multiplexer state from the Registry
-        public static NvMuxState NvMuxGetState() {
-            using(RegistryKey key = Registry.LocalMachine.OpenSubKey(Config.RegMuxKey, true))
-                return (NvMuxState) (int) key.GetValue(Config.RegMuxValue);
+        // Retrieves the current nVidia multiplexer state from the Registry, or null
+        // when the system has no such key/value. The mux registry key only exists on
+        // NV-Optimus laptops, so on an AMD/Intel-only or non-mux machine OpenSubKey
+        // returns null and GetValue could also be absent — the previous unconditional
+        // dereference threw a NullReferenceException there (C1). Callers compare the
+        // result against NvMuxState.Discrete, which a null cleanly fails.
+        public static NvMuxState? NvMuxGetState() {
+            using(RegistryKey key = Registry.LocalMachine.OpenSubKey(Config.RegMuxKey, true)) {
+                object value = key?.GetValue(Config.RegMuxValue);
+                if(value == null)
+                    return null;
+                return (NvMuxState) (int) value;
+            }
         }
 #endregion
 

--- a/OmenMon.csproj
+++ b/OmenMon.csproj
@@ -30,7 +30,7 @@
     <StartupObject>OmenMon.App</StartupObject>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <WarningLevel>4</WarningLevel>
-    <AssemblyVersion Condition="'$(AssemblyVersion)' == ''">1.4.4.0</AssemblyVersion>
+    <AssemblyVersion Condition="'$(AssemblyVersion)' == ''">1.4.5.0</AssemblyVersion>
     <AssemblyVersionWord Condition="'$(AssemblyVersionWord)' == ''">reborn</AssemblyVersionWord>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/OmenMon.xml
+++ b/OmenMon.xml
@@ -88,6 +88,13 @@
              provoke an ACPI "EC did not respond before timeout" panic shutdown
              (issue #88). Set >= EcWaitLimit to restore the legacy pure-spin. -->
         <EcWaitSpinCount>5</EcWaitSpinCount>
+        <!-- Iterations after EcWaitSpinCount that merely yield the timeslice
+             (Thread.Sleep(0)) before escalating to a full 1 ms sleep. Because
+             Wait() runs while the Global\Access_EC mutex is held, an all-1 ms
+             backoff could pin the mutex past EcMutexTimeout and starve other
+             waiters into ErrEcLock; yielding first bounds the worst-case hold
+             (A4, issue #88). Set to 0 to escalate to the 1 ms sleep immediately. -->
+        <EcWaitYieldCount>10</EcWaitYieldCount>
         <!-- Fan Control -->
         <!-- Fan countdown will always be continually extended, even
              with no fan program running, no constant-speed button
@@ -593,7 +600,12 @@
             <!-- 8E71: HP Omen 16-am1000 (2026 BIOS) — confirmed via Auto-Calibration Wizard (issue #22). -->
             <!-- Classic 16-bit LE RPM tachometers at 0xB0/0xB2 (CPU max ~3660, GPU max ~3630 RPM).       -->
             <!-- Fan level at 0x11/0x12, rate write at 0x3A/0x3B — standard 2023+ layout.                 -->
-            <Model ProductId="8E71" DisplayName="HP Omen 16-am1000 (2026)">
+            <!-- Also covers the HP Omen 16-am1001nw (issue #31, @Bart82 — the same #88 EC-timeout         -->
+            <!-- reporter): am1001nw is a regional SKU of the am1xxx generation and is expected to report  -->
+            <!-- this same 8E71 ProductId and EC layout. If an am1001nw owner's -Diag shows a different    -->
+            <!-- ProductId or the RPM/controls misbehave, post it on #31 so a dedicated entry can ship —   -->
+            <!-- HP does occasionally fork the EC layout across regional am1xxx variants.                  -->
+            <Model ProductId="8E71" DisplayName="HP Omen 16-am1000 / am1001nw (2026)">
                 <FanLevelReg0>17</FanLevelReg0>
                 <FanLevelReg1>18</FanLevelReg1>
                 <FanRateReadReg0>46</FanRateReadReg0>
@@ -776,6 +788,33 @@
                 <FanRateWriteReg1>45</FanRateWriteReg1>
                 <FanSpeedReg0>176</FanSpeedReg0>
                 <FanSpeedReg1>178</FanSpeedReg1>
+                <CountdownReg>99</CountdownReg>
+                <ManualReg>98</ManualReg>
+                <ModeReg>149</ModeReg>
+                <SwitchReg>244</SwitchReg>
+            </Model>
+            <!-- 8D41: HP Omen Max 16 (2025) — issue #87 (@Keith1341), #90.                          -->
+            <!-- Graduated from the read-only AutoCal.KnownBoards RPM mapping (added v1.4.4) to a     -->
+            <!-- full native entry. Confirmed 16-bit LE tachometers at 0x5C (CPU) / 0x9F (GPU):       -->
+            <!-- the report's 100% step decodes EC[0x5C..0x5D]=80 16 → 5760 RPM and                   -->
+            <!-- EC[0x9F..0xA0]=85 19 → 6533 RPM, with the 0% step reading 0/0 — so FanSpeedReg0/1 =   -->
+            <!-- 92/159 (0x5C/0x9F). Without this entry the platform fell back to PlatformPreset.      -->
+            <!-- Default and read the wrong 0xB0/0xB2 tach (RPM was only correct via AutoCal.Prime).   -->
+            <!-- Fan CONTROL registers are the standard legacy defaults (Manual 0x62, Mode 0x95,       -->
+            <!-- Switch 0xF4, Countdown 0x63) — IDENTICAL to what the unknown-model fallback already   -->
+            <!-- applied for this board, so naming the entry is non-regressive for control while       -->
+            <!-- fixing the RPM read. The control map is still UNVERIFIED on this 2025 "Max" layout;    -->
+            <!-- if a user reports the fan slider/manual mode has no effect, post a -Diag so the        -->
+            <!-- control registers can be confirmed before any control-specific override ships.        -->
+            <Model ProductId="8D41" DisplayName="HP Omen Max 16 (2025)">
+                <FanLevelReg0>17</FanLevelReg0>
+                <FanLevelReg1>18</FanLevelReg1>
+                <FanRateReadReg0>46</FanRateReadReg0>
+                <FanRateReadReg1>47</FanRateReadReg1>
+                <FanRateWriteReg0>58</FanRateWriteReg0>
+                <FanRateWriteReg1>59</FanRateWriteReg1>
+                <FanSpeedReg0>92</FanSpeedReg0>
+                <FanSpeedReg1>159</FanSpeedReg1>
                 <CountdownReg>99</CountdownReg>
                 <ManualReg>98</ManualReg>
                 <ModeReg>149</ModeReg>

--- a/wiki/Model-Database.md
+++ b/wiki/Model-Database.md
@@ -101,6 +101,7 @@ The following IDs have been reported in upstream issues. Entries marked ✅ have
 | `8DD0` | Omen (2025) | ✅ 2023+ layout, RPM at `0xB0`/`0xB2` (issue #26, false-positive auto-cal mitigated via built-in `AutoCal.Prime` in v1.4.0 — issue #33) |
 | `8D26` | Omen 16-ap0007ns (2026) | ✅ 2023+ layout, RPM at `0xB0`/`0xB2` (issue #52) |
 | `88EB` | Victus 16 (2021) | ✅ 2023+ layout, RPM at `0xB0`/`0xB2` (issue #48) |
+| `8D41` | Omen Max 16 (2025) | ✅ RPM at `0x5C`/`0x9F` (16-bit LE; CPU ≈5760, GPU ≈6533 RPM at 100%). Issues #87/#90 — graduated from the read-only `AutoCal` mapping to a native entry in v1.4.5. Fan **control** registers are the legacy defaults (identical to the unknown-model fallback) and remain **unverified** on this 2025 "Max" layout; post a `-Diag` if the slider / manual mode has no effect. |
 | `8C77` | Omen 16-wf1012nl (2024) — single-fan SKU | ⚠️ Sidecar-resolved via the Auto-Calibration Wizard (issue #50). CPU fan at `EC[0xD2]` (`PeriodEncoded8`, idle ≈ `0xB2`, max ≈ `0x11`). No GPU fan detected — likely a physically single-fan chassis, not a missed register. Not yet added to the shipped native database: waiting on a second `8C77` owner to confirm the layout is consistent across the SKU (HP recycles product IDs across regional variants). Owners can install OmenMon as normal — the wizard's `OmenMon-AutoCal.xml` keeps the install working out of the box. |
 | `8A3E` | Victus 15 fb0102la | ❓ |
 | `8748` | Omen 17 cb1046nr (2021) | ❓ |
@@ -110,6 +111,24 @@ The following IDs have been reported in upstream issues. Entries marked ✅ have
 | `878D` | Envy 15 ep0003nl (2020) | ❓ |
 
 To add a confirmed entry, open a pull request editing the default `OmenMon.xml` with the new `<Model>` block and attach the `-Probe` Markdown output as evidence.
+
+### Pending field reports (awaiting hardware data)
+
+These SKUs were reported in v1.4.5 issues but **cannot ship a native `<Model>`
+entry yet** — no confirmed Product ID + register dump is available, and HP
+recycles Product IDs across regional/CPU variants, so guessing a register map
+risks garbage RPM or a fan-controller lock on someone else's machine. They are
+**already usable today**: the read-only [Auto-Detector](Auto-Detection) picks a
+safe layout on launch, and the **Auto-Calibrate & Diagnose…** wizard resolves
+the tachometers into a local `OmenMon-AutoCal.xml`. To get a board promoted to
+the shipped database, attach the `OmenMon.exe -Diag` output (now including the
+Live Fan Telemetry table, issue #49) to the relevant issue.
+
+| Reported as | Issue | Needed to ship a native entry |
+|-------------|-------|-------------------------------|
+| HP Omen 16-wd0004nw | #51, #75 | `-Diag` Product ID + Auto-Calibration report (0/30/70/100 % sweep) confirming the tachometer registers |
+| HP (Victus/Omen) xd0020ax | #77 | `-Diag` Product ID + `-Probe` dump confirming fan-level / RPM register layout |
+| HP Omen, AMD Ryzen 9 7945HS SKU | #85 | `-Diag` Product ID + sustained-load Auto-Calibration report (a prior 7945HS-class report, #76/#85 on `8BCA`, gave conflicting tach layouts across SKUs — a third corroborating dump is needed before shipping) |
 
 ---
 

--- a/wiki/Model-Database.md
+++ b/wiki/Model-Database.md
@@ -102,6 +102,7 @@ The following IDs have been reported in upstream issues. Entries marked ✅ have
 | `8D26` | Omen 16-ap0007ns (2026) | ✅ 2023+ layout, RPM at `0xB0`/`0xB2` (issue #52) |
 | `88EB` | Victus 16 (2021) | ✅ 2023+ layout, RPM at `0xB0`/`0xB2` (issue #48) |
 | `8D41` | Omen Max 16 (2025) | ✅ RPM at `0x5C`/`0x9F` (16-bit LE; CPU ≈5760, GPU ≈6533 RPM at 100%). Issues #87/#90 — graduated from the read-only `AutoCal` mapping to a native entry in v1.4.5. Fan **control** registers are the legacy defaults (identical to the unknown-model fallback) and remain **unverified** on this 2025 "Max" layout; post a `-Diag` if the slider / manual mode has no effect. |
+| `8BA9` | Omen 16-wd0xxx (2024) — single-fan SKU | ⚠️ Read-only RPM mapping at `EC[0xF1]` (16-bit LE; idle ≈1793, max ≈5125 RPM), confirmed against the issue #92 Auto-Calibration sweep (@M1918IIBAR). No GPU fan detected (single-fan chassis). Shipped as a read-only `AutoCal` mapping, **not** a native `<Model>` entry — fan **control** registers are unverified on this board, so control stays on the safe auto-detector fallback. Post a `-Diag` if the slider / manual mode has no effect. |
 | `8C77` | Omen 16-wf1012nl (2024) — single-fan SKU | ⚠️ Sidecar-resolved via the Auto-Calibration Wizard (issue #50). CPU fan at `EC[0xD2]` (`PeriodEncoded8`, idle ≈ `0xB2`, max ≈ `0x11`). No GPU fan detected — likely a physically single-fan chassis, not a missed register. Not yet added to the shipped native database: waiting on a second `8C77` owner to confirm the layout is consistent across the SKU (HP recycles product IDs across regional variants). Owners can install OmenMon as normal — the wizard's `OmenMon-AutoCal.xml` keeps the install working out of the box. |
 | `8A3E` | Victus 15 fb0102la | ❓ |
 | `8748` | Omen 17 cb1046nr (2021) | ❓ |
@@ -126,7 +127,7 @@ Live Fan Telemetry table, issue #49) to the relevant issue.
 
 | Reported as | Issue | Needed to ship a native entry |
 |-------------|-------|-------------------------------|
-| HP Omen 16-wd0004nw | #51, #75 | `-Diag` Product ID + Auto-Calibration report (0/30/70/100 % sweep) confirming the tachometer registers |
+| HP Omen 16-wd0004nw | #51, #75 | `-Diag` Product ID + Auto-Calibration report (0/30/70/100 % sweep) confirming the tachometer registers. **Update:** a `wd0xxx` board reporting Product ID `8BA9` (#92) supplied exactly this data and is now mapped read-only (see the `8BA9` row above). A `wd0004nw` owner should confirm whether their `-Diag` also shows `8BA9` — if so, this row is covered. |
 | HP (Victus/Omen) xd0020ax | #77 | `-Diag` Product ID + `-Probe` dump confirming fan-level / RPM register layout |
 | HP Omen, AMD Ryzen 9 7945HS SKU | #85 | `-Diag` Product ID + sustained-load Auto-Calibration report (a prior 7945HS-class report, #76/#85 on `8BCA`, gave conflicting tach layouts across SKUs — a third corroborating dump is needed before shipping) |
 


### PR DESCRIPTION
EC read-path (root-cause fix for "RPM = negative/millions", #86):
- A1 (#86): EC wait fail-limit no longer returns a garbage byte; fails cleanly and keeps the last good value instead of latching into garbage.
- A2 (#86): 16-bit reads validated against torn high/low bytes (two consecutive agreeing reads).
- A3 (#86): monitoring tick batches reads under a single reentrant EC mutex hold (Hw.EcExecBatch).
- A4 (#88): graduated wait backoff (yield before 1 ms sleep) bounds the mutex hold below EcMutexTimeout, easing the ACPI-timeout shutdowns.

Threading / safety:
- B1: Initialize/Close lifecycle lock-protected (use-after-close race).
- B2: gpuTempObserved made volatile.
- C1: NvMuxGetState() null-guarded on non-Optimus systems (NvMuxState?).
- C3: thermal-panic protection runs regardless of the dynamic tray icon.

Field reports / model database:
- More robust EC layout auto-detector (#37).
- Live Fan Telemetry section in -Diag (#49).
- Native 8D41 (Omen Max 16 2025) entry (#87/#90), 8A18 ck1000nw pin (#84), 8BB3 single-fan mirror (#81), 8E71 am1001nw coverage note (#31).

Version bumped to 1.4.5 (csproj default + All/Version.cs).